### PR TITLE
Replace 'anonymous' collection with temporary user and 'temp' collection

### DIFF
--- a/webrecorder/static/recordings.js
+++ b/webrecorder/static/recordings.js
@@ -5,7 +5,7 @@ if (!user) {
 $(function() {
     EventHandlers.bindAll();
     TimesAndSizesFormatter.format();
-    CollectionsDropdown.start();
+    //CollectionsDropdown.start();
     RecordingSizeWidget.start();
     PagesComboxBox.start();
     CountdownTimer.start();
@@ -25,9 +25,6 @@ var EventHandlers = (function() {
         $('.wr-content').on('submit', '.start-recording-homepage', function(event) {
             event.preventDefault();
 
-            if (!user) {
-                user = anon_user;
-            }
             if (!user) {
                 user = "$temp";
             }
@@ -390,7 +387,7 @@ var CollectionsDropdown = (function() {
 
     var start = function() {
         // Only activate when logged in and not in record/browse mode
-        if (user == '@anon' || window.wbinfo || window.coll) {
+        if (!user || window.wbinfo || window.coll) {
             return;
         }
 

--- a/webrecorder/static/recordings.js
+++ b/webrecorder/static/recordings.js
@@ -25,7 +25,14 @@ var EventHandlers = (function() {
         $('.wr-content').on('submit', '.start-recording-homepage', function(event) {
             event.preventDefault();
 
-            var collection = "anonymous";
+            if (!user) {
+                user = anon_user;
+            }
+            if (!user) {
+                user = "$temp";
+            }
+
+            var collection = "temp";
             var title = "My First Recording";
             var url = $(".wr-content input[name='url']").val();
 
@@ -193,43 +200,23 @@ var RouteTo = (function(){
             mode = "record";
         }
 
-        if (user == "@anon") {
-            routeTo(host + "/" + collection + "/" + recording + "/" + mode + "/" + url);
-        } else {
-            routeTo(host + "/" + user + "/" + collection + "/" + recording + "/" + mode + "/" + url);
-        }
+        routeTo(host + "/" + user + "/" + collection + "/" + recording + "/" + mode + "/" + url);
     }
 
     var collectionInfo = function(user, collection) {
-        if (user == "@anon") {
-            routeTo(host + "/anonymous");
-        } else {
-            routeTo(host + "/" + user + "/" + collection);
-        }
+        routeTo(host + "/" + user + "/" + collection);
     }
 
     var recordingInfo = function(user, collection, recording) {
-        if (user == "@anon") {
-            routeTo(host + "/" + collection + "/" + recording);
-        } else {
-            routeTo(host + "/" + user + "/" + collection + "/" + recording);
-        }
+        routeTo(host + "/" + user + "/" + collection + "/" + recording);
     }
 
     var browseRecording = function(user, collection, recording, url) {
-        if (user == "@anon") {
-            routeTo(host + "/" + collection + "/" + recording + "/" + url);
-        } else {
-            routeTo(host + "/" + user + "/" + collection + "/" + recording + "/" + url);
-        }
+        routeTo(host + "/" + user + "/" + collection + "/" + recording + "/" + url);
     }
 
     var addToRecording = function(user, collection, recording) {
-        if (user == "@anon") {
-            routeTo(host + "/" + collection + "/" + recording + "/$add" );
-        } else {
-            routeTo(host + "/" + user + "/" + collection + "/" + recording + "/$add");
-        }
+        routeTo(host + "/" + user + "/" + collection + "/" + recording + "/$add");
     }
 
     var patchPage = function(user, collection, recording, url) {
@@ -476,9 +463,9 @@ var CountdownTimer = (function() {
 
     var start = function() {
         // enable timer only if anon
-        if (user != "@anon") {
-            return;
-        }
+        //if (curr_mode == "anon") {
+        //    return;
+        //}
 
         var expire = $("*[data-anon-timer]").attr("data-anon-timer");
 

--- a/webrecorder/templates/base_bootstrap.html
+++ b/webrecorder/templates/base_bootstrap.html
@@ -22,9 +22,9 @@
         <link rel="stylesheet" href="/static/__shared/styles.css"/>
 
         <script>
-            window.curr_user = "{{ curr_user if curr_user else '@anon' }}";
+            window.curr_user = "{{ curr_user if curr_user else '' }}";
             window.curr_mode = "{{ curr_mode }}";
-            window.user = "{{ user if not is_anon() else '@anon' }}";
+            window.user = "{{ user }}";
             window.coll = "{{ coll }}";
             window.rec = "{{ rec }}";
         </script>

--- a/webrecorder/templates/breadcrumbs.html
+++ b/webrecorder/templates/breadcrumbs.html
@@ -1,28 +1,20 @@
 {% if user %}
 	<ol class="navbar-left breadcrumb wr-breadcrumb">
-		{% if user and user != "@anon" %}
-			<li class="navbar-left">
-				<a target="_parent" href="/{{ user }}" title="Return to archive: {{user}}">{{ user }}</a>
-			</li>
-		{% endif %}
+                {% if not is_anon() %}
+                <li class="navbar-left">
+                        <a target="_parent" href="/{{ user }}" title="Return to archive: {{ user }}">{{ user if not is_anon() else 'Temp User' }}</a>
+                </li>
+                {% endif %}
 
 		{% if coll %}
-			<li class="navbar-left">
-			    {% if user != "@anon" %}
-	                <a target="_parent" href="/{{ user }}/{{ coll }}" title="Return to collection: {{coll}}">{{ coll }}</a>
-			    {% else %}
-	                <a target="_parent" href="/anonymous" title="Return to collection: {{coll}}">{{ coll }}</a>	
-	            {% endif %}
+                        <li class="navbar-left">
+	                <a target="_parent" href="{{ get_path(user, coll) }}" title="Return to collection: {{ coll_title }}">{{ coll_title }}</a>
 			</li>
 		{% endif %}
 
 		{% if rec and rec != '*' %}
 			<li class="navbar-left">
-			    {% if user != "@anon" %}
-	                <a target="_parent" href="/{{ user }}/{{ coll }}/{{ rec }}" title="Return to recording: {{rec}}">{{ rec }}</a>
-			    {% else %}
-	                <a target="_parent" href="/anonymous/{{ rec }}" title="Return to recording: {{rec}}">{{ rec }}</a>
-	           	{% endif %}
+	                <a target="_parent" href="{{ get_path(user, coll, rec) }}" title="Return to recording: {{ rec_title }}">{{ rec_title }}</a>
 			</li>
 		{% endif %}
 	</ol>

--- a/webrecorder/templates/index.html
+++ b/webrecorder/templates/index.html
@@ -4,10 +4,6 @@
 
 {{ super() }}
 
-<script>
-var anon_user = "{{ anon_user | default('') }}";
-</script>
-
 {% endblock %}
 
 {% block content %}

--- a/webrecorder/templates/index.html
+++ b/webrecorder/templates/index.html
@@ -4,6 +4,10 @@
 
 {{ super() }}
 
+<script>
+var anon_user = "{{ anon_user | default('') }}";
+</script>
+
 {% endblock %}
 
 {% block content %}
@@ -15,8 +19,9 @@
 {% else %}
     {% if anon_size and anon_recordings %}
         <div class="alert alert-info" role="alert">
-            Anonymously recorded <a href="/anonymous"><b data-size="{{ anon_size }}"></b></a> in <a href="/anonymous"><b>{{ anon_recordings }}</b></a> recordings(s).
-        <b style="margin-left: 10px"><a href="/anonymous">Browse</a></b>, <b><a href="/anonymous/$download">Download</a></b>, <b><a href="/anonymous">Delete</a></b><p class="pull-right">Expires in <b data-anon-timer="{{ anon_ttl }}"></b></p>
+            {% set path = get_path(anon_user, 'temp') %}
+            Anonymously recorded <a href="{{ path }}"><b data-size="{{ anon_size }}"></b></a> in <a href="{{ path }}"><b>{{ anon_recordings }}</b></a> recordings(s).
+        <b style="margin-left: 10px"><a href="{{ path }}">Browse</a></b> or <b><a href="{{ path }}/$download">Download</a></b><p class="pull-right">Expires in <b data-anon-timer="{{ anon_ttl }}"></b></p>
         </div>
     {% endif %}
 {% endif %}

--- a/webrecorder/templates/user_management_links.html
+++ b/webrecorder/templates/user_management_links.html
@@ -1,8 +1,8 @@
-{% if curr_user and curr_user != "@anon" %}
+{% if curr_user %}
     <ul class="nav wr-user-links">
         <li class="navbar-text navbar-right userset">
             <a target="_parent" title="Logout" href="/_logout">
-                <span class="glyphicon glyphicon-log-out" title="Logout"></span></a>
+            <span class="glyphicon glyphicon-log-out" title="Logout"></span></a>
         </li>
         <li class="navbar-text navbar-right userset">
             <a target="_parent" href="/{{ curr_user }}/_settings"><span title="Settings" class="glyphicon glyphicon-cog"></span></a>

--- a/webrecorder/test/test_recs_api.py
+++ b/webrecorder/test/test_recs_api.py
@@ -7,12 +7,23 @@ from .testutils import BaseWRTests
 # ============================================================================
 class TestWebRecRecAPI(BaseWRTests):
     def test_home_page(self):
-        res = self.testapp.get('/')
+        res = self._anon_get('/')
         assert 'Webrecorder' in res
         assert self.testapp.cookies == {}
 
+    def _anon_post(self, url, *args, **kwargs):
+        return self.testapp.post(url.format(user=self.anon_user), *args, **kwargs)
+
+    def _anon_get(self, url, *args, **kwargs):
+        return self.testapp.get(url.format(user=self.anon_user), *args, **kwargs)
+
+    def test_get_anon_user(self):
+        res = self.testapp.get('/api/v1/anon_user')
+        TestWebRecRecAPI.anon_user = res.json['anon_user']
+        assert self.anon_user != ''
+
     def test_create_anon_rec(self):
-        res = self.testapp.post('/api/v1/recordings?user=@anon&coll=anonymous', params={'title': 'My Rec'})
+        res = self._anon_post('/api/v1/recordings?user={user}&coll=temp', params={'title': 'My Rec'})
 
         assert self.testapp.cookies['__test_sesh'] != ''
 
@@ -20,10 +31,10 @@ class TestWebRecRecAPI(BaseWRTests):
 
         anon_user = self.get_anon_user()
 
-        assert self.redis.exists('r:' + anon_user + ':anonymous:my-rec:info')
+        assert self.redis.exists('r:' + anon_user + ':temp:my-rec:info')
 
-    def test_get_anon_rec(self):
-        res = self.testapp.get('/api/v1/recordings/my-rec?user=@anon&coll=anonymous')
+    def test_anon_get_anon_rec(self):
+        res = self._anon_get('/api/v1/recordings/my-rec?user={user}&coll=temp')
 
         assert res.json['recording']
         rec = res.json['recording']
@@ -31,12 +42,12 @@ class TestWebRecRecAPI(BaseWRTests):
         assert rec['size'] == 0
         assert rec['id'] == 'my-rec'
         assert rec['title'] == 'My Rec'
-        assert rec['download_url'] == 'http://localhost:80/anonymous/my-rec/$download'
+        assert rec['download_url'] == 'http://localhost:80/{user}/temp/my-rec/$download'.format(user=self.anon_user)
         assert rec['created_at'] == rec['updated_at']
         assert rec['created_at'] <= int(time.time())
 
     def test_create_another_anon_rec(self):
-        res = self.testapp.post('/api/v1/recordings?user=@anon&coll=anonymous', params={'title': '2 Another! Recording!'})
+        res = self._anon_post('/api/v1/recordings?user={user}&coll=temp', params={'title': '2 Another! Recording!'})
 
         assert self.testapp.cookies['__test_sesh'] != ''
 
@@ -44,79 +55,79 @@ class TestWebRecRecAPI(BaseWRTests):
 
         anon_user = self.get_anon_user()
 
-        assert self.redis.exists('r:' + anon_user + ':anonymous:2-another-recording:info')
+        assert self.redis.exists('r:' + anon_user + ':temp:2-another-recording:info')
 
     def test_list_all_recordings(self):
-        res = self.testapp.get('/api/v1/recordings?user=@anon&coll=anonymous')
+        res = self._anon_get('/api/v1/recordings?user={user}&coll=temp')
 
         recs = res.json['recordings']
         assert len(recs) == 2
 
         assert recs[0]['id'] == '2-another-recording'
         assert recs[0]['title'] == '2 Another! Recording!'
-        assert recs[0]['download_url'] == 'http://localhost:80/anonymous/2-another-recording/$download'
+        assert recs[0]['download_url'] == 'http://localhost:80/{user}/temp/2-another-recording/$download'.format(user=self.anon_user)
 
         assert recs[1]['id'] == 'my-rec'
         assert recs[1]['title'] == 'My Rec'
-        assert recs[1]['download_url'] == 'http://localhost:80/anonymous/my-rec/$download'
+        assert recs[1]['download_url'] == 'http://localhost:80/{user}/temp/my-rec/$download'.format(user=self.anon_user)
 
     def test_page_list_0(self):
-        res = self.testapp.get('/api/v1/recordings/my-rec/pages?user=@anon&coll=anonymous')
+        res = self._anon_get('/api/v1/recordings/my-rec/pages?user={user}&coll=temp')
 
         assert res.json == {'pages': []}
 
     def test_page_add_1(self):
         page = {'title': 'Example', 'url': 'http://example.com/', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/my-rec/pages?user=@anon&coll=anonymous', params=page)
+        res = self._anon_post('/api/v1/recordings/my-rec/pages?user={user}&coll=temp', params=page)
 
         assert res.json == {}
 
     def test_page_list_1(self):
-        res = self.testapp.get('/api/v1/recordings/my-rec/pages?user=@anon&coll=anonymous')
+        res = self._anon_get('/api/v1/recordings/my-rec/pages?user={user}&coll=temp')
 
         assert res.json == {'pages': [{'title': 'Example', 'url': 'http://example.com/', 'ts': '2016010203000000'}]}
 
     def test_page_add_2(self):
         page = {'title': 'Example', 'url': 'http://example.com/foo/bar', 'ts': '2015010203000000'}
-        res = self.testapp.post('/api/v1/recordings/my-rec/pages?user=@anon&coll=anonymous', params=page)
+        res = self._anon_post('/api/v1/recordings/my-rec/pages?user={user}&coll=temp', params=page)
 
         assert res.json == {}
 
     def test_page_list_2(self):
-        res = self.testapp.get('/api/v1/recordings/my-rec/pages?user=@anon&coll=anonymous')
+        res = self._anon_get('/api/v1/recordings/my-rec/pages?user={user}&coll=temp')
         assert len(res.json['pages']) == 2
         assert {'title': 'Example', 'url': 'http://example.com/', 'ts': '2016010203000000'} in res.json['pages']
         assert {'title': 'Example', 'url': 'http://example.com/foo/bar', 'ts': '2015010203000000'} in res.json['pages']
 
     def test_collide_wb_url_format(self):
-        res = self.testapp.post('/api/v1/recordings?user=@anon&coll=anonymous', params={'title': '2016'})
+        res = self._anon_post('/api/v1/recordings?user={user}&coll=temp', params={'title': '2016'})
         assert res.json['recording']['id'] == '2016_'
 
     def test_collide_wb_url_format_2(self):
-        res = self.testapp.post('/api/v1/recordings?user=@anon&coll=anonymous', params={'title': '2ab_'})
+        res = self._anon_post('/api/v1/recordings?user={user}&coll=temp', params={'title': '2ab_'})
         assert res.json['recording']['id'] == '2ab__'
 
     def test_error_already_exists(self):
-        res = self.testapp.post('/api/v1/recordings?user=@anon&coll=anonymous', params={'title': '2 Another Recording'}, status=400)
+        res = self._anon_post('/api/v1/recordings?user={user}&coll=temp', params={'title': '2 Another Recording'}, status=400)
         assert res.json == {'error_message': 'Recording Already Exists', 'id': '2-another-recording', 'title': '2 Another! Recording!'}
 
     def test_error_no_such_rec(self):
-        res = self.testapp.get('/api/v1/recordings/blah@$?user=@anon&coll=anonymous', status=404)
+        res = self._anon_get('/api/v1/recordings/blah@$?user={user}&coll=temp', status=404)
         assert res.json == {'error_message': 'Recording not found', 'id': 'blah@$'}
 
     def test_error_no_such_rec_pages(self):
-        res = self.testapp.get('/api/v1/recordings/my-rec3/pages?user=@anon&coll=anonymous', status=404)
+        res = self._anon_get('/api/v1/recordings/my-rec3/pages?user={user}&coll=temp', status=404)
         assert res.json == {'error_message': 'Recording not found', 'id': 'my-rec3'}
 
         page = {'title': 'Example', 'url': 'http://example.com/foo/bar', 'ts': '2015010203000000'}
-        res = self.testapp.post('/api/v1/recordings/my-rec3/pages?user=@anon&coll=anonymous', params=page, status=404)
+        res = self._anon_post('/api/v1/recordings/my-rec3/pages?user={user}&coll=temp', params=page, status=404)
         assert res.json == {'error_message': 'Recording not found', 'id': 'my-rec3'}
 
     def test_error_missing_user_coll(self):
-        res = self.testapp.post('/api/v1/recordings', params={'title': 'Recording'}, status=400)
+        res = self._anon_post('/api/v1/recordings', params={'title': 'Recording'}, status=400)
         assert res.json == {'error_message': "User must be specified"}
 
     def test_error_invalid_user_coll(self):
-        res = self.testapp.post('/api/v1/recordings?user=user&coll=coll', params={'title': 'Recording'}, status=404)
+        res = self._anon_post('/api/v1/recordings?user=user&coll=coll', params={'title': 'Recording'}, status=404)
         assert res.json == {"error_message": "No such user"}
 

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -30,6 +30,8 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
         cls.testapp = webtest.TestApp(cls.appcont.app)
         cls.redis = FakeStrictRedis.from_url(os.environ['REDIS_BASE_URL'])
 
+        cls.anon_user = None
+
     @classmethod
     def set_nx_env(self, name, value):
         if os.environ.get(name) is None:
@@ -37,8 +39,8 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
 
     @classmethod
     def get_anon_user(cls):
-        anon_user = 'anon/' + cls.testapp.cookies['__test_sesh'][-32:]
-        return anon_user
+        #anon_user = 'anon/' + cls.testapp.cookies['__test_sesh'][-32:]
+        return cls.anon_user
 
     @classmethod
     def get_root_dir(cls):

--- a/webrecorder/webrecorder/appcontroller.py
+++ b/webrecorder/webrecorder/appcontroller.py
@@ -158,8 +158,9 @@ class AppController(BaseController):
 
             elif sesh.is_anon():
                 anon_user = sesh.anon_user
-                anon_coll = self.manager.get_collection(anon_user, 'anonymous')
+                anon_coll = self.manager.get_collection(anon_user, 'temp')
                 if anon_coll:
+                    resp['anon_user'] = anon_user
                     resp['anon_size'] = anon_coll['size']
                     resp['anon_recordings'] = len(anon_coll['recordings'])
 

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -28,9 +28,9 @@ class BaseController(object):
                               api=api)
 
         if self.manager.is_anon(user):
-            user = self.manager.get_anon_user()
+            return user
 
-        elif not self.manager.has_user(user):
+        if not self.manager.has_user(user):
             self._raise_error(404, 'No such user', api=api)
 
         return user
@@ -43,8 +43,9 @@ class BaseController(object):
             self._raise_error(400, 'Collection must be specified',
                               api=api)
 
-        if request.query.get('user') == '@anon':
-            coll = 'anonymous'
+        if self.manager.is_anon(user):
+            if coll != 'temp':
+                self._raise_error(404, 'No such collection', api=api)
 
         elif not self.manager.has_collection(user, coll):
             self._raise_error(404, 'No such collection', api=api)
@@ -67,8 +68,8 @@ class BaseController(object):
 
     def get_path(self, user, coll=None, rec=None):
         base = '/'
-        if not self.manager.is_anon(user):
-            base += user
+        #if not self.manager.is_anon(user):
+        base += user
 
         if coll:
             if not base.endswith('/'):
@@ -143,10 +144,10 @@ class BaseController(object):
         return os.environ['WEBAGG_HOST']
 
     def get_view_user(self, user):
-        if self.manager.is_anon(user):
-            return '@anon'
-        else:
-            return user
+        #if self.manager.is_anon(user):
+        #    return '@anon'
+        #else:
+        return user
 
     def get_body_class(self, action):
         if action in ["add_to_recording", "new_recording"]:

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -20,7 +20,6 @@ class CollsController(BaseController):
     def __init__(self, *args, **kwargs):
         super(CollsController, self).__init__(*args, **kwargs)
         self.DOWNLOAD_COLL_PATH = '{host}/{user}/{coll}/$download'
-        self.ANON_DOWNLOAD_COLL_PATH = '{host}/anonymous/$download'
 
     def init_routes(self):
         @self.app.post('/api/v1/collections')
@@ -134,12 +133,12 @@ class CollsController(BaseController):
                 self.redirect(self.get_path(user, coll))
 
         # ANON COLLECTION
-        @self.app.get(['/anonymous', '/anonymous/'])
-        @self.jinja2_view('collection_info.html')
-        def anon_coll_info():
-            user = self.get_session().anon_user
+        #@self.app.get(['/anonymous', '/anonymous/'])
+        #@self.jinja2_view('collection_info.html')
+        #def anon_coll_info():
+        #    user = self.get_session().anon_user
 
-            return self.get_collection_info_for_view(user, 'anonymous')
+        #    return self.get_collection_info_for_view(user, 'anonymous')
 
         # LOGGED-IN COLLECTION
         @self.app.get(['/<user>/<coll>', '/<user>/<coll>/'])
@@ -177,11 +176,7 @@ class CollsController(BaseController):
         return {'collection': self._add_download_path(collection, user)}
 
     def _add_download_path(self, coll_info, user):
-        if self.manager.is_anon(user):
-            path = self.ANON_DOWNLOAD_COLL_PATH
-        else:
-            path = self.DOWNLOAD_COLL_PATH
-
+        path = self.DOWNLOAD_COLL_PATH
         path = path.format(host=self.get_host(),
                            user=user,
                            coll=coll_info['id'])

--- a/webrecorder/webrecorder/recscontroller.py
+++ b/webrecorder/webrecorder/recscontroller.py
@@ -8,7 +8,6 @@ class RecsController(BaseController):
     def __init__(self, *args, **kwargs):
         super(RecsController, self).__init__(*args, **kwargs)
         self.DOWNLOAD_REC_PATH = '{host}/{user}/{coll}/{rec}/$download'
-        self.ANON_DOWNLOAD_REC_PATH = '{host}/anonymous/{rec}/$download'
 
     def init_routes(self):
         @self.app.post('/api/v1/recordings')
@@ -72,15 +71,6 @@ class RecsController(BaseController):
             pages = self.manager.list_pages(user, coll, rec)
             return {'pages': pages}
 
-        # ANON NEW REC
-        @self.app.get(['/anonymous/$new', '/anonymous/$new/'])
-        @self.jinja2_view('new_recording.html')
-        def anon_new_recording():
-
-            user = self.get_session().anon_user
-
-            return self.get_rec_info_for_new(user, 'anonymous', None, 'new_recording')
-
         # LOGGED-IN NEW REC
         @self.app.get(['/<user>/<coll>/$new', '/<user>/<coll>/$new/'])
         @self.jinja2_view('new_recording.html')
@@ -88,30 +78,12 @@ class RecsController(BaseController):
 
             return self.get_rec_info_for_new(user, coll, None, 'new_recording')
 
-        # ANON ADD TO REC
-        @self.app.get(['/anonymous/<rec>/$add', '/anonymous/<rec>/$add/'])
-        @self.jinja2_view('add_to_recording.html')
-        def anon_add_to_recording(rec):
-
-            user = self.get_session().anon_user
-
-            return self.get_rec_info_for_new(user, 'anonymous', rec, 'add_to_recording')
-
         # LOGGED-IN ADD TO REC
         @self.app.get(['/<user>/<coll>/<rec>/$add', '/<user>/<coll>/<rec>/$add/'])
         @self.jinja2_view('add_to_recording.html')
         def add_to_recording(user, coll, rec):
 
             return self.get_rec_info_for_new(user, coll, rec, 'add_to_recording')
-
-        # ANON REC VIEW
-        @self.app.get(['/anonymous/<rec>', '/anonymous/<rec>/'])
-        @self.jinja2_view('recording_info.html')
-        def anon_rec_info(rec):
-
-            user = self.get_session().anon_user
-
-            return self.get_rec_info_for_view(user, 'anonymous', rec)
 
         # LOGGED-IN REC VIEW
         @self.app.get(['/<user>/<coll>/<rec>', '/<user>/<coll>/<rec>/'])
@@ -171,14 +143,11 @@ class RecsController(BaseController):
         result['coll'] = coll
         result['rec'] = rec
 
-        if coll != 'anonymous':
-            collection = self.manager.get_collection(user, coll)
-            if not collection:
-                self._raise_error(404, 'Collection not found')
+        collection = self.manager.get_collection(user, coll)
+        if not collection:
+            self._raise_error(404, 'Collection not found')
 
-            result['coll_title'] = collection['title']
-        else:
-            result['coll_title'] = 'anonymous'
+        result['coll_title'] = collection['title']
 
         if rec:
             recording = self.manager.get_recording(user, coll, rec)
@@ -190,11 +159,7 @@ class RecsController(BaseController):
         return result
 
     def _add_download_path(self, rec_info, user, coll):
-        if self.manager.is_anon(user):
-            path = self.ANON_DOWNLOAD_REC_PATH
-        else:
-            path = self.DOWNLOAD_REC_PATH
-
+        path = self.DOWNLOAD_REC_PATH
         path = path.format(host=self.get_host(),
                            user=user,
                            coll=coll,

--- a/webrecorder/webrecorder/redisman.py
+++ b/webrecorder/webrecorder/redisman.py
@@ -283,7 +283,13 @@ class AccessManagerMixin(object):
     PUBLIC = '@public'
 
     def is_anon(self, user):
-        return not user or user == '@anon' or user.startswith('anon/')
+        #return not user or user == '@anon' or user.startswith('anon/')
+        if not user:
+            return False
+
+        sesh = request.environ['webrec.session']
+
+        return sesh.is_anon(user)
 
     def get_curr_user(self):
         sesh = request.environ['webrec.session']
@@ -608,10 +614,10 @@ class Base(object):
 
         info['size_remaining'] = self.get_size_remaining(user)
 
-        if self.is_anon(user):
-            info['user'] = '@anon'
-        else:
-            info['user'] = user
+        #if self.is_anon(user):
+        #    info['user'] = '@anon'
+        #else:
+        info['user'] = user
 
         return info
 

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -17,6 +17,9 @@ Available collections are listed below.
         @self.app.get(['/<user>', '/<user>/'])
         @self.jinja2_view('user.html')
         def user_info(user):
+            if self.manager.is_anon(user):
+                self.redirect('/' + user + '/temp')
+
             self.manager.assert_user_exists(user)
 
             result = {'user': user,
@@ -28,6 +31,10 @@ Available collections are listed below.
                 result['user_info']['desc'] = self.DEFAULT_USER_DESC.format(user)
 
             return result
+
+        @self.app.get('/api/v1/anon_user')
+        def get_anon_user():
+            return {'anon_user': self.manager.get_anon_user(True)}
 
         @self.app.post('/api/v1/users/<user>/desc')
         def update_desc(user):


### PR DESCRIPTION
Use consistent `user/coll/rec` paths for temporary collections, remove redundant code for 'anonymous'