### PR TITLE
home page: allow specifying a recording name

### DIFF
--- a/webrecorder/static/recordings.js
+++ b/webrecorder/static/recordings.js
@@ -31,11 +31,11 @@ var EventHandlers = (function() {
             if (!user) {
                 user = "$temp";
                 var collection = "temp";
-                var title = "My First Recording";
             } else {
                 var collection = $('[data-collection-id]').attr('data-collection-id');
-                var title = $("input[name='title']").val();
             }
+
+            var title = $("input[name='rec-title']").val();
             var url = $(".start-recording-homepage input[name='url']").val();
 
             RouteTo.recordingInProgress(user, collection, title, url);
@@ -52,12 +52,40 @@ var EventHandlers = (function() {
                     '<span class="caret"></span>'));
         });
 
+        function getNewRecTitle() {
+            return "Recording At " + new Date().toISOString().substring(0, 19).replace("T", " ");
+        }
+
+        $(".wr-gen-rec-name").on('click', function(event) {
+            event.preventDefault();
+
+            $("input[name='rec-title']").val(getNewRecTitle());
+        });
+
+        // Set default recording title if it is empty
+        var rec_title_input = $("input[name='rec-title']");
+
+        if (rec_title_input.length) {
+            if (!rec_title_input.val()) {
+                rec_title_input.val(getNewRecTitle());
+            }
+        }
+
+        // If logged-in user and has collection selector (homepage)
+        // select first collection
+        if (user) {
+            var collSelect = $(".collection-select");
+            if (collSelect.length > 0) {
+                collSelect[0].click();
+            }
+        }
+
         // 'New recording': Start button
         $('header').on('submit', '.start-recording', function(event) {
             event.preventDefault();
 
             var collection = $('[data-collection-id]').attr('data-collection-id');
-            var title = $("input[name='title']").val();
+            var title = $("input[name='rec-title']").val();
             var url = $("input[name='url']").val();
 
             RouteTo.recordingInProgress(user, collection, title, url);

--- a/webrecorder/static/styles.css
+++ b/webrecorder/static/styles.css
@@ -263,6 +263,26 @@ tbody {
     margin-left: 7px;
     margin-left: 7px;
 }
+
+.glyphicon.glyphicon-dot:before {
+    content: "\25cf";
+    font-size: 2em;
+    line-height: 0.3em;
+}
+
+.glyphicon.glyphicon-dot-sm:before {
+    content: "\25cf";
+    font-size: 1.5em;
+    line-height: 0.3em;
+}
+
+.glyphicon.glyphicon-dot-lg:before {
+    content: "\25cf";
+    font-size: 2em;
+    vertical-align: sub;
+    line-height: 0.1em;
+}
+
 /* End glyphicons */
 
 

--- a/webrecorder/templates/index.html
+++ b/webrecorder/templates/index.html
@@ -2,48 +2,48 @@
 
 {% block head %}
 
-    {{ super() }}
+{{ super() }}
 
 {% endblock %}
 
 {% block body %}
 
-    <div class="homepage-user-links row right-padding top-buffer right-buffer left-buffer">
-        {% include 'user_management_links.html' %}
-    </div>
+<div class="homepage-user-links row right-padding top-buffer right-buffer left-buffer">
+    {% include 'user_management_links.html' %}
+</div>
 
-    <div class="container wr-content">
-        {% block message%}
+<div class="container wr-content">
+    {% block message %}
 
-            {{ super() }}
+    {{ super() }}
 
-            {% include 'temporary_collection_info.html' %}
-
-        {% endblock %}
-
-        {% block content %}
-            <div class="row top-buffer">
-                <h1 class="text-center"><strong>webrecorder.io</strong></h1>
-            </div>
-
-            <div class="row top-buffer-lg bottom-buffer-lg">
-                {% include 'recordings/homepage_recorder.html' %}
-            </div>
-
-            {% if is_anon and invites_enabled %}
-                <div class="row top-buffer">
-                    <div class="col-md-offset-1 col-md-10">
-                        <h4>We are inviting users to build their own archives as we test this service.</h4>
-                        <h4><a href="/_register">Request an invite to sign-up</a></h4>
-                    </div>
-                </div>
-            {% endif %}
-        {% endblock %}
-    </div>
-
-    {% block footer %}
-        {% include 'footer.html' %}
     {% endblock %}
 
-    {% include 'login_modal.html' %}
+    {% block content %}
+    <div class="row top-buffer">
+        <h1 class="text-center"><strong>webrecorder.io</strong></h1>
+    </div>
+
+    {% include 'temporary_collection_info.html' %}
+
+    <div class="row top-buffer-lg bottom-buffer-lg">
+        {% include 'recordings/homepage_recorder.html' %}
+    </div>
+
+    {% if is_anon and invites_enabled %}
+    <div class="row top-buffer">
+        <div class="col-md-offset-1 col-md-10">
+            <h4>We are inviting users to build their own archives as we test this service.</h4>
+            <h4><a href="/_register">Request an invite to sign-up</a></h4>
+        </div>
+    </div>
+    {% endif %}
+    {% endblock %}
+</div>
+
+{% block footer %}
+{% include 'footer.html' %}
+{% endblock %}
+
+{% include 'login_modal.html' %}
 {% endblock %}

--- a/webrecorder/templates/recordings/homepage_recorder.html
+++ b/webrecorder/templates/recordings/homepage_recorder.html
@@ -1,52 +1,53 @@
 {% if is_out_of_space() %}
-    {% set disabled_class = "disabled" %}
+{% set disabled_class = "disabled" %}
 {% endif %}
 
-{% if curr_user %}
-	<form class="start-recording-homepage">
+<form class="start-recording-homepage form-inline">
 
-		<div class="input-group col-md-8 col-md-offset-2">
-			<div class="input-group-btn">
-			  <button type="button" class="btn btn-default dropdown-toggle dropdown-toggle-collection" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-				<span class="dropdown-toggle-label">Collection </span><span class="caret"></span>
-			  </button>
-			  <ul class="dropdown-menu">
-				{% for collection in collections %}
-					<li>
-						<a href="#" class="collection-select" data-collection-id="{{ collection.id }}">{{ collection.title }}</a>
-					</li>
-				{% endfor %}
-			    <li role="separator" class="divider"></li>
-			    <li>
-	                <a href="#" data-toggle="modal" data-target="#create-modal" role="button">
-						<span class="glyphicon glyphicon-plus right-buffer-sm"></span>New Collection
-	                </a>
-			    </li>
-			  </ul>
-			</div>
+    <div class="input-group col-md-10 col-md-offset-2">
+        <input name="url" type="text" class="form-control" placeholder="Url to record" required {{ disabled_class }}>
+        <label for="url" class="control-label sr-only">Url</label>
+        <span class="input-group-btn">
+            <button type="submit" class="btn btn-default {{ disabled_class }}">
+                <span class="glyphicon glyphicon-dot-lg"></span>Record</button>
+        </span>
+    </div>
 
-			<label for="title" class="sr-only">Recording title:</label>
-		    <input name="title" type="text" class="form-control" placeholder="Recording title" value="{{ rec_title }}" required {{ disabled_class }}>
-		</div>
+    <div class="form-group col-md-10 col-md-offset-2 top-buffer">
+        <label for="recording">Recording Name:</label>
+        
+        <span class="input-group">
+            <input name="rec-title" type="text" class="form-control input-sm" style="width: 225px" placeholder="" value="{{ rec_title }}" required {{ disabled_class }}>
+            <span class="input-group-btn">
+                <button type="button" title="Generate Recording Session Name" class="wr-gen-rec-name btn btn-sm btn-default"><span class="glyphicon glyphicon-time"></span></button>
+            </span>
+        </span>
 
-		<div class="input-group col-md-8 col-md-offset-2 top-buffer">
-		    <input name="url" type="text" class="form-control" placeholder="Url to record" required {{ disabled_class }}>
-		    <label for="url" class="control-label sr-only">Url</label>
-		    <span class="input-group-btn">
-		        <button type="submit" class="btn btn-default {{ disabled_class }}">Record</button>
-		    </span>
-		</div>
-	</form>
+        {% if curr_user %}
+        <label style="margin-left: 20px" for="collection">Add to collection:</label>
+        
+        <span class="dropdown">
+            <button type="button" name="collection" class="btn btn-default dropdown-toggle dropdown-toggle-collection" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false" {{ disabled_class }}>
+                <span class="dropdown-toggle-label">Collection </span><span class="caret"></span>
+            </button>
 
-	{% include '/create_collection_modal.html' %}
-{% else %}
-	<form class="start-recording-homepage">
-	    <div class="input-group col-md-8 col-md-offset-2">
-	        <input name="url" type="text" class="form-control" placeholder="Url to record" required {{ disabled_class }}>
-	        <label for="url" class="control-label sr-only">Url</label>
-	        <span class="input-group-btn">
-	            <button type="submit" class="btn btn-default {{ disabled_class }}">Record</button>
-	        </span>
-	    </div>
-	</form>
-{% endif %}
+            <ul class="dropdown-menu">
+                {% for collection in collections %}
+                <li>
+                    <a href="#" class="collection-select" data-collection-id="{{ collection.id }}">{{ collection.title }}</a>
+                </li>
+                {% endfor %}
+                <li role="separator" class="divider"></li>
+                <li>
+                    <a href="#" data-toggle="modal" data-target="#create-modal" role="button">
+                        <span class="glyphicon glyphicon-plus right-buffer-sm"></span>New Collection
+                    </a>
+                </li>
+            </ul>
+        </span>
+        {% endif %}
+        
+    </div>
+</form>
+
+{% include '/create_collection_modal.html' %}

--- a/webrecorder/templates/recordings/new.html
+++ b/webrecorder/templates/recordings/new.html
@@ -12,8 +12,8 @@
 		</div>
 
 		<div class="pull-left top-buffer-sm left-buffer">
-			<label for="title" class="sr-only">Recording title</label>
-		    <input name="title" type="text" class="form-control input-sm title-inline" placeholder="Recording title" value="{{ rec_title }}" required>
+			<label for="rec-title" class="sr-only">Recording title</label>
+		    <input name="rec-title" type="text" class="form-control input-sm title-inline" placeholder="Recording title" value="{{ rec_title }}" required>
 		</div>
 	</div>
 

--- a/webrecorder/templates/register.html
+++ b/webrecorder/templates/register.html
@@ -8,11 +8,11 @@
 $(function() {
     $("input[name='move-temp']").on("change", function() {
         if ($(this).attr("value") == "1") {
-            $("#to_coll").parent().show();
-            $("#to_coll").attr("required", "true");
+            $("#to-coll").parent().show();
+            $("#to-coll").attr("required", "true");
         } else {
-            $("#to_coll").parent().hide();
-            $("#to_coll").attr("required", "false");
+            $("#to-coll").parent().hide();
+            $("#to-coll").attr("required", "false");
         }
     });
 });

--- a/webrecorder/templates/temporary_collection_info.html
+++ b/webrecorder/templates/temporary_collection_info.html
@@ -27,6 +27,9 @@
                                 <li><a href="{{ path }}">Temporary Collection</a></li>
                                 </ol>
                             </li>
+                            <li>
+                                Continue recording by entering another url below and clicking <b>Record</b>
+                            </li>
                         </ul>
                     </div>
                 </div>

--- a/webrecorder/test/test_all_register_migrate.py
+++ b/webrecorder/test/test_all_register_migrate.py
@@ -64,7 +64,7 @@ class TestRegisterMigrate(FullStackTests):
 
     def test_val_user_reg(self):
         res = self.testapp.get(val_reg_url)
-        assert res.headers['Location'] == 'http://localhost:80/someuser'
+        assert res.headers['Location'] == 'http://localhost:80/'
 
         user_info = self.redis.hgetall('u:someuser')
         user_info = self.appcont.manager._format_info(user_info)

--- a/webrecorder/test/test_login.py
+++ b/webrecorder/test/test_login.py
@@ -157,14 +157,11 @@ class TestLogin(BaseWRTests):
 
     def test_val_user_reg(self):
         res = self.testapp.get(self.val_reg_url)
-        assert res.headers['Location'] == 'http://localhost:80/someuser'
+        assert res.headers['Location'] == 'http://localhost:80/'
 
-        # already validated?
+        # already validated, logged in, so ignore
         res = self.testapp.get(self.val_reg_url)
-        assert res.headers['Location'] == 'http://localhost:80/_register'
-
-        res = self.testapp.get('/_valreg/blah')
-        assert res.headers['Location'] == 'http://localhost:80/_register'
+        assert res.headers['Location'] == 'http://localhost:80/'
 
         assert self.testapp.cookies.get('__test_sesh', '') != ''
 
@@ -179,6 +176,14 @@ class TestLogin(BaseWRTests):
         res = self.testapp.get('/_logout')
         assert res.headers['Location'] == 'http://localhost:80/'
         assert self.testapp.cookies.get('__test_sesh', '') == ''
+
+    def test_invalid_val_reg(self):
+        # already validated, not logged in
+        res = self.testapp.get(self.val_reg_url)
+        assert res.headers['Location'] == 'http://localhost:80/_register'
+
+        res = self.testapp.get('/_valreg/blah')
+        assert res.headers['Location'] == 'http://localhost:80/_register'
 
     def test_login(self):
         res = self.testapp.get('/_login')

--- a/wr.yaml
+++ b/wr.yaml
@@ -79,6 +79,21 @@ user_desc: |
 
     Available collections are listed below.
 
+# Default Collection created with new user
+# if not migrating temp collection
+default_coll:
+    id: 'default-collection'
+    title: 'Default Collection'
+    desc: |
+        #### Default Collection
+
+        *This is your first collection created automatically*
+
+        You can rename, change this description and make this collection public.
+
+        You can also create additional collections via the **Create New Collection** option
+        and orgranize your recordings accordingly.
+
 
 # WARC Paths and Names
 #warc_path_templ: '{user}/{coll}/{rec}/'


### PR DESCRIPTION
recording name: defaults to a name including current timestamp, both on home page and new rec screen
when logged in, allow selecting a collection
login: if not migrating a collection, automatically create 'Default Collection' so that a collection always exists
experiment: redirect to home page instead of user page after logging in so user can start recording right away
into newly created collection.
login ops: disallow register/login/forgot/validate ops if already logged
default collection: id, title, desc defined in wr.yaml
closes #81