### PR TITLE
sessions: no more beaker! use custom sessions to support:

### DIFF
--- a/webrecorder/.coveragerc
+++ b/webrecorder/.coveragerc
@@ -1,4 +1,5 @@
 [run]
+concurrency = gevent
 omit =
     */test/*
     */tests/*

--- a/webrecorder/Dockerfile
+++ b/webrecorder/Dockerfile
@@ -10,6 +10,8 @@ ADD requirements.txt /build/
 
 RUN pip install -r requirements.txt
 
+RUN pip install itsdangerous
+
 #ENV PYWB_VERSION -e git+https://github.com/ikreymer/pywb.git@develop#egg=pywb-0.30-develop
 
 #RUN pip install $PYWB_VERSION

--- a/webrecorder/requirements.txt
+++ b/webrecorder/requirements.txt
@@ -1,12 +1,8 @@
 youtube_dl
-beaker
-git+git://github.com/didip/beaker_extensions.git
+itsdangerous
 bottle
 uwsgi
 gevent
 boto
 requests>=2.9.1
 bottle-cork==0.12.0
-#-e git+https://github.com/ikreymer/bottle-cork.git@template-args#egg=bottle-cork-0.11.1
-git+http://github.com/ikreymer/warcsigner.git@py3#egg=warcsigner-0.4.0
-#warcsigner==0.3.1

--- a/webrecorder/test/test_invites_config.yaml
+++ b/webrecorder/test/test_invites_config.yaml
@@ -20,4 +20,6 @@ session_opts:
 
     session.expire: 1800
 
+    key_template: sesh:{0}
+
 

--- a/webrecorder/test/test_no_invites_config.yaml
+++ b/webrecorder/test/test_no_invites_config.yaml
@@ -20,4 +20,5 @@ session_opts:
 
     session.expire: 1800
 
+    key_template: sesh:{0}
 

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -24,6 +24,7 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
             os.environ['WR_USER_CONFIG'] = os.path.join(cls.get_curr_dir(), extra_config_file)
 
         os.environ['REDIS_BASE_URL'] = 'redis://localhost:6379/2'
+        cls.set_nx_env('REDIS_SESSION_URL', 'redis://localhost:6379/0')
 
         cls.set_nx_env('REDIS_BROWSER_URL', 'redis://localhost:6379/0')
         cls.set_nx_env('WEBAGG_HOST', 'http://localhost:8010')

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -1,19 +1,31 @@
-from bottle import request
 from datetime import timedelta
 import os
 import base64
+import pickle
+
+from webrecorder.cookieguard import CookieGuard
+from itsdangerous import URLSafeTimedSerializer, BadSignature
 
 
 # ============================================================================
 class Session(object):
-    def __init__(self, cork, anon_duration):
+    def __init__(self, cork, anon_duration, key, sesh, ttl):
         self.anon_duration = anon_duration
-        self.sesh = request.environ.get('beaker.session')
+
+        self.sesh = sesh
+        self.key = key
+
         self.curr_user = None
         self.curr_role = None
 
+        self.should_delete = False
+        self.should_save = False
+
+        self.ttl = ttl
+
         try:
-            if self.sesh.get('anon'):
+            self._anon = self.sesh.get('anon')
+            if self._anon:
                 self.curr_role = 'anon'
             else:
                 self.curr_user = self.sesh.get('username')
@@ -24,8 +36,7 @@ class Session(object):
             print(e)
             self.curr_user = None
             self.curr_role = None
-            if self.sesh:
-                self.sesh.delete()
+            self.should_delete = True
 
         message, msg_type = self.pop_message()
 
@@ -34,33 +45,26 @@ class Session(object):
                   'message': message,
                   'msg_type': msg_type}
 
-        if self.curr_role == 'anon':
-            params['anon_ttl'] = self._anon_ttl()
+        self.template_params = params
 
-            anon_user = self.sesh['anon']
-            self.sesh.namespace.db_conn.set('t:' + anon_user, self.sesh.id)
+    def save(self):
+        self.should_save = True
 
+    def __getitem__(self, name):
+        return self.sesh[name]
 
-        request.environ['webrec.template_params'] = params
+    def __setitem__(self, name, value):
+        self.sesh[name] = value
 
-    def _anon_ttl(self):
-        key = self.sesh.namespace._format_key('session')
-        return self.sesh.namespace.db_conn.ttl(key)
-
-    def update_expires(self):
-        # force expires to be updated
-        self.sesh.cookie_expires = timedelta(seconds=self.anon_duration)
-        self.sesh['_expires'] = self.sesh._set_cookie_expires(None)
-        self.sesh.save()
-        self.sesh._update_cookie_out()
+    def get(self, name, value=None):
+        return self.sesh.get(name, value)
 
     def set_anon(self):
         if not self.curr_user:
-            anon_user = self.make_anon_user()
+            self.sesh['anon'] = self.anon_user
 
-            self.sesh['anon'] = anon_user
-
-            self.update_expires()
+            #self.update_expires()
+            self.save()
 
     def is_anon(self, user=None):
         if self.curr_user:
@@ -77,15 +81,19 @@ class Session(object):
 
     @property
     def anon_user(self):
-        anon = self.sesh.get('anon')
-        if not anon:
-            anon = self.make_anon_user()
-        return anon
+        if self._anon:
+            return self._anon
+
+        self._anon = self.sesh.get('anon')
+        if not self._anon:
+            self._anon = self.make_anon_user()
+
+        return self._anon
 
     def flash_message(self, msg, msg_type='danger'):
         if self.sesh:
             self.sesh['message'] = msg_type + ':' + msg
-            self.sesh.save()
+            self.save()
         else:
             print('No Message')
 
@@ -97,7 +105,7 @@ class Session(object):
         message = self.sesh.get('message', '')
         if message:
             self.sesh['message'] = ''
-            self.sesh.save()
+            self.save()
 
         if ':' in message:
             msg_type, message = message.split(':', 1)
@@ -109,4 +117,114 @@ class Session(object):
         return 'temp!' + base64.b32encode(os.urandom(5)).decode('utf-8')
 
 
+# ============================================================================
+class RedisSessionMiddleware(CookieGuard):
+    def __init__(self, app, cork, redis, session_opts):
+        super(RedisSessionMiddleware, self).__init__(app, session_opts['session.key'])
+        self.redis = redis
+        self.cork = cork
+        self.secret_key = session_opts['session.secret']
+        self.key_template = session_opts['key_template']
+        self.anon_duration = session_opts['session.expire']
 
+    def init_session(self, environ):
+        sesh_cookie = self.split_cookie(environ)
+
+        data = None
+
+        sesh_id = self.signed_cookie_to_id(sesh_cookie, self.anon_duration)
+
+        if sesh_id:
+            redis_key = self.key_template.format(sesh_id)
+
+            data = self.redis.get(redis_key)
+            if data:
+                data = pickle.loads(base64.b64decode(data))
+                ttl = self.redis.ttl(redis_key)
+
+        # make new session
+        if data is None:
+            sesh_id = self.make_id()
+
+            redis_key = self.key_template.format(sesh_id)
+
+            data = {'id': sesh_id}
+
+            ttl = -2
+
+        session = Session(self.cork,
+                          self.anon_duration,
+                          redis_key,
+                          data,
+                          ttl)
+
+        if session.curr_role == 'anon':
+            session.template_params['anon_ttl'] = ttl
+
+            anon_user = session.sesh['anon']
+            self.redis.set('t:' + anon_user, sesh_id)
+
+        environ['webrec.template_params'] = session.template_params
+        environ['webrec.session'] = session
+
+    def prepare_response(self, environ, headers):
+        super(RedisSessionMiddleware, self).prepare_response(environ, headers)
+
+        session = environ['webrec.session']
+
+        if session.should_delete:
+            self._delete_cookie(headers, self.sesh_key)
+        else:
+            if session.should_save:
+                data = base64.b64encode(pickle.dumps(session.sesh))
+                self.redis.set(session.key, data)
+
+            if self.should_set_cookie(session):
+                self.set_cookie_and_duration(session, headers)
+
+    def should_set_cookie(self, session):
+        # new or expired session, set if saving session
+        if session.ttl < 0:
+            return session.should_save
+
+        # if anon, don't set again (allow expiry)
+        if session.curr_role == 'anon':
+            return False
+
+        # if not anon, refresh is time is running out
+        if session.ttl < 120:
+            return True
+
+    def set_cookie_and_duration(self, session, headers):
+        sesh_cookie = self.id_to_signed_cookie(session.sesh['id'])
+
+        value = '{0}={1}; Path=/; max-age={2}'.format(self.sesh_key,
+                                              sesh_cookie,
+                                              self.anon_duration)
+
+        self.redis.expire(session.key, self.anon_duration)
+
+        headers.append(('Set-Cookie', value))
+
+    def signed_cookie_to_id(self, sesh_cookie, max_age):
+        if not sesh_cookie:
+            return None
+
+        sesh_cookie = sesh_cookie.strip()
+        if not sesh_cookie.startswith(self.sesh_key + '='):
+            return None
+
+        sesh_cookie = sesh_cookie[len(self.sesh_key) + 1:]
+
+        serial = URLSafeTimedSerializer(self.secret_key)
+
+        try:
+            return serial.loads(sesh_cookie, max_age=max_age * 2)
+        except BadSignature as b:
+            return None
+
+    def id_to_signed_cookie(self, sesh_id):
+        return URLSafeTimedSerializer(self.secret_key).dumps(sesh_id)
+
+    def make_id(self):
+        return base64.b64encode(os.urandom(20)).decode('utf-8')

--- a/webrecorder/webrecorder/webreccork.py
+++ b/webrecorder/webrecorder/webreccork.py
@@ -70,7 +70,8 @@ class WebRecCork(Cork):
 
         cork = WebRecCork(backend=backend,
                     email_sender=email_sender,
-                    smtp_url=smtp_url)
+                    smtp_url=smtp_url,
+                    session_key_name='webrec.session')
         return cork
 
     @staticmethod

--- a/wr.env
+++ b/wr.env
@@ -1,5 +1,6 @@
 REDIS_BASE_URL=redis://redis:6379/1
 REDIS_BROWSER_URL=redis://redis:6379/0
+REDIS_SESSION_URL=redis://redis:6379/0
 
 WEBAGG_HOST=http://webagg:8080
 RECORD_HOST=http://recorder:8010

--- a/wr.yaml
+++ b/wr.yaml
@@ -1,6 +1,6 @@
 
 # Durations
-anon_duration: 1800
+#anon_duration: 1800
 
 default_max_size: 1000000000
 default_max_anon_size: 1000000000
@@ -16,7 +16,7 @@ session_opts:
     session.validate_key: $VALIDATE_KEY
 
     session.auto: false
-    session.cookie_expires: True
+    session.cookie_expires: 60
 
     session.httponly: true
     session.cookie_path: '/'
@@ -26,7 +26,9 @@ session_opts:
 
     session.url: $REDIS_BASE_URL
 
-    session.expire: 1800
+    session.expire: 5400
+
+    key_template: 'sesh:{0}'
 
 
 # Upstream url templates


### PR DESCRIPTION
- anon/temp users get a fixed amount of time from session creation, shown by timer, does not refresh
- logged in users get a fixed session which extends automatically if less than threshold remaining
- todo: remember me option (or longer logged in sessions?)