### PR TITLE
Mailing list support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@ nosetests.xml
 .vagrant
 
 # webrecorder specific
-webrecorder/webrecorder.env
 wr.env
 webrecorder/keys/
 data/

--- a/webrecorder/uwsgi.ini
+++ b/webrecorder/uwsgi.ini
@@ -26,10 +26,6 @@ mules = 1
 wsgi = webrecorder.main
 env = PYWB_CONFIG_FILE=config.yaml
 
-for-readline = webrecorder.env
-  env = %(_)
-endfor =
-
 static-map = /static/__pywb=/code/src/pywb/static
 #static-map = /static/__shared=/code/static
 

--- a/wr_sample.env
+++ b/wr_sample.env
@@ -36,6 +36,20 @@ EMAIL_SMTP_URL=smtp://test@localhost:archive@webrecorder_mailserver_1:25
 # SSL SMTP Example: if using an external service, can use the SSL form, as follows
 #EMAIL_SMTP_URL=ssl://user@host:password@smtp.example.com:465
 
+# Mailing list -- optional 3rd party mailing list management
+# =============================
+# Flag to enable
+MAILING_LIST=false
+
+# API endpoint
+MAILING_LIST_ENDPOINT=
+
+# API key
+MAILING_LIST_KEY=
+
+# JSON API payload with python template formatting, available feilds: username, email
+MAILING_LIST_PAYLOAD={{"email_address":"{email}","status":"subscribed"}}
+
 # Redis
 # ==============================
 # Redis Urls for reading, and redis server for master

--- a/wr_sample.env
+++ b/wr_sample.env
@@ -1,6 +1,5 @@
 # Webrecorder Env
 # This file contains deployment specific params
-# Please rename this file to webrecorder.env and fill in the appropriate fields
 
 # Default storage (local, s3, etc...)
 DEFAULT_STORAGE=local


### PR DESCRIPTION
Adds `MAILING_LIST` flag to the `wr.env` config to enable 3rd party mailing list support. 
`MAILING_LIST_ENDPOINT`, `MAILING_LIST_KEY`, `MAILING_LIST_PAYLOAD` are configurable.