### PR TITLE
downloadcontroller: fix download of individual recording WARCs #234

### DIFF
--- a/wr.yaml
+++ b/wr.yaml
@@ -56,6 +56,8 @@ download_paths:
     rec: '{host}/{user}/{coll}/{rec}/$download'
     coll: '{host}/{user}/{coll}/$download'
 
+download_chunk_encoded: true
+
 
 # Misc Settings
 invites_enabled: $REQUIRE_INVITES


### PR DESCRIPTION
support both chunk-encoding and normal non-chunked download where the content-length is computed for the entire WARC
via the 'download_chunked_encoded' config setting (defaults to true)