### PR TITLE
recorder refactor: allow WebRecRecorder to be scaled to multiple proc…

### DIFF
--- a/webrecorder/apps/frontend.ini
+++ b/webrecorder/apps/frontend.ini
@@ -19,9 +19,7 @@ endif =
 log-x-forwarded-for = true
 
 gevent = 400
-#threads = 10
 processes = 10
-mules = 1
 
 # specify config file here
 wsgi = webrecorder.main

--- a/webrecorder/apps/rec.ini
+++ b/webrecorder/apps/rec.ini
@@ -12,8 +12,11 @@ if-env = VIRTUAL_ENV
 venv = $(VIRTUAL_ENV)
 endif =
 
-gevent = 1000
-processes = 1
+gevent = 400
+processes = 10
+
+mule = ./webrecorder/rec/tempchecker.py
+mule = ./webrecorder/rec/storagecommitter.py
 
 wsgi = webrecorder.rec.app
 

--- a/webrecorder/test/test_all_temp_content.py
+++ b/webrecorder/test/test_all_temp_content.py
@@ -16,6 +16,7 @@ from six.moves.urllib.parse import urlsplit
 from urllib.parse import quote
 
 from webrecorder.session import Session
+import gevent
 
 
 # ============================================================================
@@ -31,6 +32,12 @@ class TestTempContent(FullStackTests):
         'h:defaults',
         'h:temp-usage',
     ]
+
+    def setup_class(cls, **kwargs):
+        super(TestTempContent, cls).setup_class(**kwargs)
+
+        from webrecorder.rec.tempchecker import run
+        gevent.spawn(run)
 
     def _get_redis_keys(self, keylist, user, coll, rec):
         keylist = [key.format(user=user, coll=coll, rec=rec) for key in keylist]

--- a/webrecorder/webrecorder/fullstackrunner.py
+++ b/webrecorder/webrecorder/fullstackrunner.py
@@ -15,8 +15,7 @@ except:
 
 # ==================================================================
 class FullStackRunner(object):
-    def __init__(self, app_port=8090, rec_port=0, agg_port=0,
-                 local_only=False, env_params=None):
+    def __init__(self, app_port=8090, rec_port=0, agg_port=0, env_params=None):
 
         if env_params:
             os.environ.update(env_params)
@@ -27,7 +26,7 @@ class FullStackRunner(object):
 
         def recorder():
             from webrecorder.rec.main import init as record_init
-            return record_init(local_only=local_only)
+            return record_init()
 
         def app():
             from webrecorder.appcontroller import AppController

--- a/webrecorder/webrecorder/rec/main.py
+++ b/webrecorder/webrecorder/rec/main.py
@@ -1,82 +1,20 @@
 from gevent import monkey; monkey.patch_all()
 
-from webrecorder.rec.webrecrecorder import WebRecRecorder
-from webrecorder.rec.tempchecker import TempChecker
-from webrecorder.rec.storagecommitter import StorageCommitter
-
 from webrecorder.utils import load_wr_config
+from webrecorder.rec.webrecrecorder import WebRecRecorder
 
 import gevent
-import os
-
-from webrecorder.rec.s3 import S3Storage
 
 
 # =============================================================================
-#def start_uwsgi_timer(freq, type_, callable_, signal=66):
-#    import uwsgi
-#    uwsgi.register_signal(signal, type_, callable_)
-#    uwsgi.add_timer(signal, freq)
-
-#start_uwsgi_timer(5, "mule", run_temp_checker)
-
-#def run_temp_checker(self, signum=None):
-#    temp_checker()
-
-
-#wr = None
-
-# =============================================================================
-def temp_checker_loop(temp_checker, sleep_secs):
-    print('Running temp delete check every {0}'.format(sleep_secs))
-    while True:
-        try:
-            temp_checker()
-            gevent.sleep(sleep_secs)
-        except:
-            import traceback
-            traceback.print_exc()
-
-
-# =============================================================================
-def storage_commit_loop(storage_committer, writer, sleep_secs):
-    print('Running storage committer {0}'.format(sleep_secs))
-    while True:
-        try:
-            writer.close_idle_files()
-
-            storage_committer()
-            gevent.sleep(sleep_secs)
-        except:
-            import traceback
-            traceback.print_exc()
-
-
-# =============================================================================
-def init(local_only=False):
+def init():
     config = load_wr_config()
-
-    temp_checker = None
-    storage_committer = None
 
     wr = WebRecRecorder(config)
 
-    if not local_only:
-        temp_checker = TempChecker(config)
-        storage_committer = StorageCommitter(config)
+    gevent.spawn(wr.msg_listen_loop)
 
-        storage_committer.add_storage_class('s3', S3Storage)
-
-        sleep_secs = int(os.environ.get('TEMP_SLEEP_CHECK', 30))
-
-        gevent.spawn(temp_checker_loop, temp_checker, sleep_secs)
-        gevent.spawn(wr.msg_listen_loop)
-
-    wr.init_app(storage_committer)
-
-    if not local_only:
-        gevent.spawn(storage_commit_loop, storage_committer, wr.writer, sleep_secs)
-
+    wr.init_app(None)
     wr.app.wr = wr
 
     return wr.app

--- a/webrecorder/webrecorder/rec/tempchecker.py
+++ b/webrecorder/webrecorder/rec/tempchecker.py
@@ -3,6 +3,9 @@ import os
 import json
 import glob
 import requests
+import time
+
+from webrecorder.utils import load_wr_config
 
 
 # ============================================================================
@@ -95,3 +98,22 @@ class TempChecker(object):
                 self._delete_if_expired(temp_user)
 
 
+# =============================================================================
+def run():
+    config = load_wr_config()
+    temp_checker = TempChecker(config)
+
+    sleep_secs = int(os.environ.get('TEMP_SLEEP_CHECK', 30))
+
+    print('Running temp delete check every {0}'.format(sleep_secs))
+    while True:
+        try:
+            temp_checker()
+            time.sleep(sleep_secs)
+        except:
+            import traceback
+            traceback.print_exc()
+
+
+if __name__ == "__main__":
+    run()

--- a/webrecorder/webrecorder/rec/webrecrecorder.py
+++ b/webrecorder/webrecorder/rec/webrecrecorder.py
@@ -148,6 +148,7 @@ class WebRecRecorder(object):
 
         self.pubsub.subscribe('delete')
         self.pubsub.subscribe('rename')
+        self.pubsub.subscribe('close_idle')
 
         print('Waiting for messages')
 
@@ -161,6 +162,9 @@ class WebRecRecorder(object):
 
                 elif item['channel'] == b'rename':
                     self.handle_rename_local(item['data'].decode('utf-8'))
+
+                elif item['channel'] == b'close_idle':
+                    self.recorder.writer.close_idle_files()
 
             except:
                 import traceback

--- a/webrecorder/webrecorder/standalone/standalone.py
+++ b/webrecorder/webrecorder/standalone/standalone.py
@@ -54,8 +54,7 @@ class StandaloneRunner(FullStackRunner):
 
         self.admin_init()
 
-        super(StandaloneRunner, self).__init__(local_only=True,
-                                               app_port=app_port,
+        super(StandaloneRunner, self).__init__(app_port=app_port,
                                                rec_port=rec_port,
                                                agg_port=agg_port)
         atexit.register(self.close)


### PR DESCRIPTION
…esses more easily

split TempChecker and StorageCommitter into separate scripts, decoupled fro WebRecRecorder, run as uwsgi mules
add 'close_idle' message sent periodically to close idle files in each WebRecRecorder process
simplify standalone build, remove unused local_only logic and param
test: add TempChecker as greenlet for temp test