### PR TITLE
HAR support: add support for uploading HTTP Archive (.har) or loading…

### DIFF
--- a/webrecorder/requirements.txt
+++ b/webrecorder/requirements.txt
@@ -8,4 +8,5 @@ marshmallow
 werkzeug
 urllib3
 karellen-geventws
+har2warc
 fakeredis

--- a/webrecorder/webrecorder/standalone/webrecorder_player.py
+++ b/webrecorder/webrecorder/standalone/webrecorder_player.py
@@ -13,7 +13,7 @@ from gevent.threadpool import ThreadPool
 
 # ============================================================================
 class WebrecPlayerRunner(StandaloneRunner):
-    ARCHIVE_EXT = ('.warc', '.arc', '.warc.gz', '.arc.gz', '.warcgz', '.arcgz')
+    ARCHIVE_EXT = ('.warc', '.arc', '.warc.gz', '.arc.gz', '.warcgz', '.arcgz', '.har')
 
     def __init__(self, argres):
         self.inputs = argres.inputs

--- a/webrecorder/webrecorder/static/uploader.js
+++ b/webrecorder/webrecorder/static/uploader.js
@@ -224,7 +224,7 @@ Uploader = (function() {
         $("#choose-upload-file").on('change', function() {
             var filename = $(this).val().replace(/^C:\\fakepath\\/i, "");
 
-            if (!filename.match(/\.w?arc(\.gz)?$/)) {
+            if (!filename.match(/\.w?arc(\.gz)?|\.har$/)) {
                 status.text("Sorry, only WARC or ARC files (.warc, .warc.gz, .arc, .arc.gz) can be uploaded");
                 status.addClass("upload-error");
                 status.show();

--- a/webrecorder/webrecorder/templates/upload_modal.html
+++ b/webrecorder/webrecorder/templates/upload_modal.html
@@ -29,7 +29,7 @@
                                 <div class="upload-percent"></div>
                             </div>
                             <div id="upload-status"></div>
-                            <input type="file" name="upload-file" id="choose-upload-file" style="display: none" accept=".gz,.warc,.arc">
+                            <input type="file" name="upload-file" id="choose-upload-file" style="display: none" accept=".gz,.warc,.arc,.har">
                             <input type="hidden" id="force-coll" name="force-coll" value="{{ collection.id if collection else ''}}">
                         </div>
                     </div>

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -23,6 +23,7 @@ class CacheingLimitReader(LimitReader):
         super(CacheingLimitReader, self).__init__(stream, length)
         self.out = out
         self.lenread = 0
+        self.closed = False
 
     def read(self, size=-1):
         buff = super(CacheingLimitReader, self).read(size)
@@ -32,6 +33,15 @@ class CacheingLimitReader(LimitReader):
 
     def tell(self):
         return self.lenread
+
+    def readable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def seekable(self):
+        return False
 
 
 # ============================================================================
@@ -51,6 +61,19 @@ class SizeTrackingReader(CacheingLimitReader):
     def __init__(self, stream, length, redis, key):
         super(SizeTrackingReader, self).__init__(stream, length,
                                                  SizeTrackingWriter(redis, key))
+
+        self.closed = False
+
+    def readable(self):
+        return True
+
+    def writable(self):
+        return False
+
+    def seekable(self):
+        return False
+
+
 
 
 


### PR DESCRIPTION
… .har into player #322

use har2warc to convert to har->warc on the fly by writing to a temp WARC file
for upload, temp file is deleted after storing in user dir
for standalone player, temp file is removed on shutdown