### PR TITLE
setup: auto-generate 'webrecorder/git_hash.py' with current git commi…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ nosetests.xml
 wr.env
 webrecorder/keys/
 data/
+git_hash.py

--- a/webrecorder/setup.py
+++ b/webrecorder/setup.py
@@ -27,6 +27,23 @@ def load_requirements(filename):
         res.append(PYWB_DEP)
         return res
 
+
+def get_git_short_hash():
+    import subprocess
+    try:
+        return subprocess.check_output(['git', 'rev-parse', '--short', 'HEAD']).rstrip().decode('utf-8')
+    except:
+        return ''
+
+def generate_git_hash_py(pkg):
+    try:
+        git_hash = get_git_short_hash()
+        with open(os.path.join(pkg, 'git_hash.py'), 'wt') as fh:
+            fh.write('git_hash = "{0}"\n'.format(git_hash))
+    except:
+        pass
+
+
 class PyTest(TestCommand):
     def finalize_options(self):
         TestCommand.finalize_options(self)
@@ -46,7 +63,9 @@ class Install(install):
     def initialize_options(self):
         from webrecorder.standalone.assetsutils import default_build
         default_build()
+        generate_git_hash_py('webrecorder')
         super(Install, self).initialize_options()
+
 
 
 setup(

--- a/webrecorder/webrecorder/standalone/webrecorder_player.py
+++ b/webrecorder/webrecorder/standalone/webrecorder_player.py
@@ -68,7 +68,8 @@ class WebrecPlayerRunner(StandaloneRunner):
 
     @classmethod
     def add_args(cls, parser):
-        parser.add_argument('inputs', nargs='+')
+        parser.add_argument('inputs', nargs='*',
+                            help='web archive (.warc.gz, .warc, .arc.gz, .arc or .har files)')
 
 
 


### PR DESCRIPTION
…t hash

version: support -v/--version which prints current package version and hash, and pywb version and hash
gitignore: add git_hash.py to gitignore