### PR TITLE
add anonymous rate-limiting support: if enabled via wr.env, users

### DIFF
--- a/webrecorder/webrecorder/config/wr.yaml
+++ b/webrecorder/webrecorder/config/wr.yaml
@@ -53,7 +53,7 @@ url_templates:
     # core replay funcs
     live: '{live_host}/live/resource/postreq?'
 
-    record: '{record_host}/record/live/resource/postreq?param.user={user}&param.coll={coll}&param.rec={rec}'
+    record: '{record_host}/record/live/resource/postreq?param.user={user}&param.coll={coll}&param.rec={rec}&param.ip={ip}'
     patch: '{record_host}/record/patch/resource/postreq?param.user={user}&param.coll={coll}&param.recorder.rec={rec}&param.replay.rec=*'
     snapshot: '{record_host}/record/live/resource/postreq?param.user={user}&param.coll={coll}&param.rec={rec}&put_record=resource'
 
@@ -153,6 +153,8 @@ mount_key_templ: 'r:{user}:{coll}:{rec}:cdxj_m'
 
 user_usage_key: 'h:user-usage'
 temp_usage_key: 'h:temp-usage'
+
+rate_limit_key: 'ipr:{ip}:{H}'
 
 cookie_key_templ: 'r:{user}:{coll}:{rec}:{id}:cookie:'
 

--- a/webrecorder/webrecorder/config/wr_sample.env
+++ b/webrecorder/webrecorder/config/wr_sample.env
@@ -15,6 +15,13 @@ REQUIRE_INVITES=false
 APP_HOST=
 CONTENT_HOST=
 
+# Rate limiting for anon users
+# (0 = disabled, no rate limiting)
+# If both > 0,  users can record upto RATE_LIMIT_MAX bytes
+# over RATE_LIMIT_HOURS
+RATE_LIMIT_MAX=0
+RATE_LIMIT_HOURS=0
+
 # S3 Options (onlt if using S3)
 # =============================
 

--- a/webrecorder/webrecorder/templates/error.html
+++ b/webrecorder/webrecorder/templates/error.html
@@ -37,6 +37,8 @@
       <div class="panel-body">
         {% if err.status_code == 404 %}
         No such page or content is not accessible.
+        {% elif err.status_code == 402 and err.body == 'Rate Limit' %}
+        <p>Sorry, you have exceeded the rate limit for anonymous recording.</p><p>Please <a href="/_register" target="_parent" ><strong>Sign Up</strong></a> or <a href="/_login_modal" class="login-link">Login</a> to continue recording.</p>
         {% else %}
         {{ err.body }}
         {% endif %}


### PR DESCRIPTION
can record upto X bytes over Y hours.
limiting done by ip (using x-real-ip header if available) #343