### PR TITLE
Develop->Master

### DIFF
--- a/webrecorder/requirements.txt
+++ b/webrecorder/requirements.txt
@@ -9,4 +9,4 @@ werkzeug
 gevent-websocket
 har2warc
 fakeredis
-wsgiprox>=1.2
+wsgiprox==1.4

--- a/webrecorder/webrecorder/appcontroller.py
+++ b/webrecorder/webrecorder/appcontroller.py
@@ -123,9 +123,18 @@ class AppController(BaseController):
 
         final_app = WSGIProxMiddleware(final_app, '/_proxy/',
                                        proxy_host='webrecorder.proxy',
-                                       proxy_options={'ca_root_dir': 'proxy-certs'})
+                                       proxy_options=self._get_proxy_options())
 
         super(AppController, self).__init__(final_app, jinja_env, manager, config)
+
+    def _get_proxy_options(self):
+        opts = {'ca_name': 'Webrecorder HTTPS Proxy CA'}
+        if getattr(sys, 'frozen', False):
+            opts['ca_file_cache'] = {}
+        else:
+            opts['ca_file_cache'] = './proxy-certs/webrecorder-ca.pem'
+
+        return opts
 
     def init_jinja_env(self, config):
         assets_path = os.path.expandvars(config['assets_path'])

--- a/webrecorder/webrecorder/appcontroller.py
+++ b/webrecorder/webrecorder/appcontroller.py
@@ -122,7 +122,7 @@ class AppController(BaseController):
                                            config)
 
         final_app = WSGIProxMiddleware(final_app, '/_proxy/',
-                                       proxy_host='webrecorder.io',
+                                       proxy_host='webrecorder.proxy',
                                        proxy_options={'ca_root_dir': 'proxy-certs'})
 
         super(AppController, self).__init__(final_app, jinja_env, manager, config)

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -476,15 +476,14 @@ class ContentController(BaseController, RewriterApp):
         return remote_ip
 
     ## RewriterApp overrides
-    def get_upstream_url(self, wb_url, kwargs, params):
-        upstream_url = kwargs.get('upstream_url')
-        if not upstream_url:
-            return super(ContentController, self).get_upstream_url(wb_url, kwargs, params)
-
-        upstream_url = upstream_url.format(url=quote_plus(kwargs['url']), postreq='/postreq')
-        return upstream_url
-
     def get_base_url(self, wb_url, kwargs):
+        # for proxy mode, 'upstream_url' already provided
+        # just use that
+        base_url = kwargs.get('upstream_url')
+        if base_url:
+            base_url = base_url.format(**kwargs)
+            return base_url
+
         type = kwargs['type']
 
         base_url = self.paths[type].format(record_host=self.record_host,

--- a/webrecorder/webrecorder/standalone/assetsutils.py
+++ b/webrecorder/webrecorder/standalone/assetsutils.py
@@ -45,28 +45,6 @@ def default_build():
     build(assets_path)
 
 
-# =================================================================
-def get_pkg_version(pkg, attr='git_hash'):
-    import pkg_resources
-    version = pkg_resources.get_distribution(pkg).version
-
-    try:
-        import importlib
-        git_hash = getattr(importlib.import_module(pkg + '.' + attr), attr)
-    except:
-        git_hash = ''
-
-    if git_hash:
-        version += ' (@{0})'.format(git_hash)
-
-    return version
-
-
-def get_version_str():
-    return '%s {0}\npywb {1}'.format(get_pkg_version('webrecorder'),
-                                     get_pkg_version('pywb'))
-
-
 # ==================================================================
 if __name__ == "__main__":
     default_build()

--- a/webrecorder/webrecorder/standalone/hooks/hook-webrecorder.py
+++ b/webrecorder/webrecorder/standalone/hooks/hook-webrecorder.py
@@ -1,7 +1,8 @@
 from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 import os
 
-from webrecorder.standalone.assetsutils import build, get_version_str
+from webrecorder.standalone.assetsutils import build
+from webrecorder.standalone.versionbuild import get_version_str
 
 def rename(old, new, t):
     return [(n, v.replace(old, new)) for n, v in t]

--- a/webrecorder/webrecorder/standalone/standalone.py
+++ b/webrecorder/webrecorder/standalone/standalone.py
@@ -1,8 +1,7 @@
 from webrecorder.fullstackrunner import FullStackRunner
 
 from webrecorder.admin import main as admin_main
-from webrecorder.standalone.assetsutils import patch_bundle
-
+from webrecorder.standalone.versionbuild import get_full_version
 
 from argparse import ArgumentParser, RawTextHelpFormatter
 
@@ -45,6 +44,7 @@ class StandaloneRunner(FullStackRunner):
 
         self.admin_init()
 
+        from webrecorder.standalone.assetsutils import patch_bundle
         patch_bundle()
 
         super(StandaloneRunner, self).__init__(app_port=app_port,
@@ -86,26 +86,6 @@ class StandaloneRunner(FullStackRunner):
             os.environ['WR_TEMPLATE_PKG'] = 'wrtemp'
 
     @classmethod
-    def print_version(cls):
-        full_version = 'unknown'
-        curr_app = sys.argv[0].rsplit(os.path.sep)[-1]
-
-        try:
-            # standalone app, read baked-in _full_version
-            if getattr(sys, 'frozen', False):
-                from pywb.utils.loaders import load
-                full_version = load('pkg://webrecorder/config/_full_version').read()
-                full_version = full_version.decode('utf-8').format(curr_app)
-            else:
-            # generate full_version dynamically
-                from webrecorder.standalone.assetsutils import get_version_str
-                full_version = get_version_str()
-        except:
-            pass
-
-        print(full_version % curr_app)
-
-    @classmethod
     def main(cls, args=None):
         parser = ArgumentParser(formatter_class=RawTextHelpFormatter)
 
@@ -120,15 +100,12 @@ class StandaloneRunner(FullStackRunner):
         parser.add_argument('--debug', action='store_true',
                             help='Enable debug logging')
 
-        parser.add_argument('-v', '--version', action='store_true',
+        parser.add_argument('-v', '--version', action='version',
+                            version=get_full_version(),
                             help='Print version and quit')
 
         cls.add_args(parser)
         r = parser.parse_args(args=args)
-
-        if r.version:
-            cls.print_version()
-            return
 
         main = cls(r)
 

--- a/webrecorder/webrecorder/standalone/versionbuild.py
+++ b/webrecorder/webrecorder/standalone/versionbuild.py
@@ -1,0 +1,47 @@
+import sys
+import os
+
+
+# ============================================================================
+def get_pkg_version(pkg, attr='git_hash'):
+    import pkg_resources
+    version = pkg_resources.get_distribution(pkg).version
+
+    try:
+        import importlib
+        git_hash = getattr(importlib.import_module(pkg + '.' + attr), attr)
+    except:
+        git_hash = ''
+
+    if git_hash:
+        version += ' (@{0})'.format(git_hash)
+
+    return version
+
+
+# ============================================================================
+def get_version_str():
+    return '%s {0}\npywb {1}'.format(get_pkg_version('webrecorder'),
+                                     get_pkg_version('pywb'))
+
+
+# ============================================================================
+def get_full_version():
+    full_version = 'unknown'
+    curr_app = sys.argv[0].rsplit(os.path.sep)[-1]
+
+    try:
+        # standalone app, read baked-in _full_version
+        if getattr(sys, 'frozen', False):
+            from pywb.utils.loaders import load
+            full_version = load('pkg://webrecorder/config/_full_version').read()
+            full_version = full_version.decode('utf-8').format(curr_app)
+        else:
+        # generate full_version dynamically
+            full_version = get_version_str()
+    except:
+        pass
+
+    return (full_version % curr_app)
+
+

--- a/webrecorder/webrecorder/standalone/webrecorder_player.py
+++ b/webrecorder/webrecorder/standalone/webrecorder_player.py
@@ -61,7 +61,8 @@ class WebrecPlayerRunner(StandaloneRunner):
                         coll='collection',
                         rec='*',
                         type='replay-coll',
-                        browser='')
+                        browser='',
+                        reqid='@INIT')
 
         #manager.browser_mgr.fill_upstream_url(local_info, None)
 

--- a/webrecorder/webrecorder/standalone/webrecorder_player.py
+++ b/webrecorder/webrecorder/standalone/webrecorder_player.py
@@ -89,7 +89,7 @@ class WebrecPlayerRunner(StandaloneRunner):
 
     @classmethod
     def add_args(cls, parser):
-        parser.add_argument('inputs', nargs='*',
+        parser.add_argument('inputs', nargs='+',
                             help='web archive (.warc.gz, .warc, .arc.gz, .arc or .har files)')
 
 

--- a/webrecorder/webrecorder/static/recordings.js
+++ b/webrecorder/webrecorder/static/recordings.js
@@ -17,6 +17,15 @@ $(function() {
     PagingInterface.start();
 });
 
+/*
+ *  Trigger synthetic inner-frame load event for Webrecorder Player
+ */
+function iframeLoadEvent() {
+    if (typeof window.iframeLoad !== "undefined") {
+        iframeLoad();
+    }
+}
+
 function setUrl(url) {
     $("input[name='url']").val(decodeURI(url));
     wbinfo.url = decodeURI(url);
@@ -1420,8 +1429,9 @@ $(function() {
 
     function handleReplayEvent(event) {
         // ignore postMessages from other sources
-        if(event.origin.indexOf(window.contentHost) === -1)
+        if (event.origin.indexOf(window.contentHost) === -1) {
             return;
+        }
 
         var replay_iframe = window.document.getElementById("replay_iframe");
 

--- a/webrecorder/webrecorder/templates/bookmarks_table.html
+++ b/webrecorder/webrecorder/templates/bookmarks_table.html
@@ -32,8 +32,7 @@
                 {% set bookmark_id = bookmark.url + ' ' + bookmark.timestamp + ' ' + (browser.id if browser else '-') %}
                 {% set title = bookmark.title if bookmark.title else "No Title" %}
                 {% set timestamp = bookmark.timestamp if bookmark.timestamp else '' %}
-                {% set path = collection_path + timestamp + '/' + bookmark.url %}
-                {% set cb_path = collection_path + timestamp + ('$br:'+browser.id if browser else '') + '/' + bookmark.url %}
+                {% set rb_path = collection_path + timestamp + ('$br:'+browser.id if browser else '') + '/' + bookmark.url %}
                 {% set hidden = "1" if bookmark.hidden == '1' else "0" %}
 
                 {% set editing_id = "bookmark-" + recording.id + "-" + timestamp + "-" + bookmark.url %}
@@ -66,22 +65,20 @@
                         {% endif %}
 
                         <td class="bookmark-title">
-                            <span class="editable-title" data-editing-id="{{ editing_id }}" class="collapse"><a href="{{ path }}">{{ title }}</a></span>
+                            <span class="editable-title" data-editing-id="{{ editing_id }}" class="collapse"><a href="{{ rb_path }}">{{ title }}</a></span>
                         </td>
 
-                        <td class="rec-browser{% if not browser %} empty{% endif %}">
+                        <td class="rec-browser{% if not browser %} empty{% endif %}" {% if browser %}title="{{ browser.name|capitalize }} version {{ browser.version }}"{% endif %}>
                             {% if browser %}
-                                <a href="{{ cb_path }}" title='{{ browser.name|capitalize }} version {{ browser.version }}'>
-                                    <img src='/api/browsers/browsers/{{ browser.id }}/icon'>
-                                    v{{ browser.version }}
-                                </a>
+                                <img src="/api/browsers/browsers/{{ browser.id }}/icon" alt="Recorded with {{ browser.name|capitalize }} version {{ browser.version }}">
+                                v{{ browser.version }}
                             {% else %}
                                 -
                             {% endif %}
                         </td>
                         <td class="timestamp" data-order="{{ timestamp }}" data-time-ts="{{ timestamp }}"></td>
                         <td class="bookmark-url">
-                          <a href="{{ path }}"
+                          <a href="{{ rb_path }}"
                              {% if '?' in bookmark.url %}title="{{ bookmark.url }}"{% endif %}
                              data-value-encoded="{{ bookmark.url|trunc_url }}"
                              data-target-decoded=""></a></td>

--- a/webrecorder/webrecorder/templates/frame_insert.html
+++ b/webrecorder/webrecorder/templates/frame_insert.html
@@ -80,7 +80,7 @@
 {% include 'header.html' %}
 {% endif %}
 
-<iframe id="replay_iframe" src="{{ iframe_url }}" onload="" seamless="seamless" frameborder="0" scrolling="yes" class="wb_iframe"></iframe>
+<iframe id="replay_iframe" src="{{ iframe_url }}" onload="iframeLoadEvent()" seamless="seamless" frameborder="0" scrolling="yes" class="wb_iframe"></iframe>
 
 {% if not is_embed %}
 {% include 'links.html' %}

--- a/webrecorder/webrecorder/templates/proxy_error.html
+++ b/webrecorder/webrecorder/templates/proxy_error.html
@@ -13,6 +13,7 @@ wbinfo.curr_browser = "{{ browser }}";
 {% assets "proxy-js" %}
 <script type="text/javascript" src="{{ host_prefix }}{{ ASSET_URL }}"></script>
 {% endassets %}
+</head>
 
 <body>
 <h2>Webrecorder Proxy Error</h2>


### PR DESCRIPTION
Proxy Related Fixes:
- Use latest wsgiprox: avoid writing proxy host certs to disk for every host (using default LRU cache of 100 certs)
- Use 'webrecorder-ca.pem' as the CA filename
- Remote browser: don't override get_upstream_url() to ensure timestamp param added same as for native browser

Standalone Player:
- Custom frame load function called, if set, to fix history in player (#352)
- Reorg version display into versionbuild.py, slightly faster version display
- At least 1 WARC param required to start player
- No proxy certs (even CA cert) written to disk when running binary player

UI:
 - Collection page bookmark links to remote browser if created with remote browser (#354)