### PR TITLE
Branding tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ nosetests.xml
 
 .vagrant
 
+# IDEs
+.idea
+
 # webrecorder specific
 wr.env
 webrecorder/keys/

--- a/webrecorder/webrecorder/templates/branding.html
+++ b/webrecorder/webrecorder/templates/branding.html
@@ -1,3 +1,0 @@
-<a target="_parent" class="navbar-left" title="Return to {{ metadata.product | default('webrecorder.io')}}" href="/">
-	webrecorder.io
-</a>

--- a/webrecorder/webrecorder/templates/error.html
+++ b/webrecorder/webrecorder/templates/error.html
@@ -26,7 +26,7 @@
         {% if curr_user %}
         <p>Create a permanent collection in <a href="/{{ curr_user }}">your account.</a></p>
         {% else %}
-        <p><a href="/_register" target="_parent" ><strong>Sign Up</strong></a> or <a href="/_login_modal" class="login-link">Login</a> to give your collection a shareable permanent address on <a href="/">webrecorder.io</a></p>
+        <p><a href="/_register" target="_parent" ><strong>Sign Up</strong></a> or <a href="/_login_modal" class="login-link">Login</a> to give your collection a shareable permanent address on <a href="/">{{ get_app_host()|default('webrecorder.io', true) }}</a></p>
         {% endif %}
       </div>
 {% else %}

--- a/webrecorder/webrecorder/templates/frame_insert.html
+++ b/webrecorder/webrecorder/templates/frame_insert.html
@@ -118,7 +118,7 @@
 <div class="embed-footer" lang="en">
 <div class="replay-wrap">
 <span>This is an archived page from <span id="replay-date" style="font-weight: bold"></span></span>
-<div style="font-size: 12px">Archived with <a target="_blank" href="https://webrecorder.io/">Webrecorder</a></div>
+<div style="font-size: 12px">Archived with <a target="_blank" href="https://{{ get_app_host()|default('webrecorder.io', true) }}/">{{ metadata.product }}</a></div>
 </div>
 </div>
 {% endif %}

--- a/webrecorder/webrecorder/templates/login_modal.html
+++ b/webrecorder/webrecorder/templates/login_modal.html
@@ -3,7 +3,7 @@
             <div class="modal-content">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4>Webrecorder Login<h4>
+                    <h4>{{ metadata.product }} Login<h4>
                 </div>
                 {% include 'login_data.html' %}
             </div>

--- a/webrecorder/webrecorder/templates/paging_display.html
+++ b/webrecorder/webrecorder/templates/paging_display.html
@@ -23,7 +23,7 @@
 {% block body %}
 
 <div class='container-fluid paging-container'>
-    <a class='home-link' href='/'><span class='glyphicon glyphicon-share-alt'></span> <span class='hidden-sm hidden-xs'>Webrecorder</span></a>
+    <a class='home-link' href='/'><span class='glyphicon glyphicon-share-alt'></span> <span class='hidden-sm hidden-xs'>{{ metadata.product }}</span></a>
     <div class='input-group col-md-10 col-md-offset-1'>
         <div class='input-group-btn'>
             <button type="button" class="btn btn-default btn-prev disabled"><span class='glyphicon glyphicon-chevron-left'></span></button>

--- a/webrecorder/webrecorder/templates/proxy_error.html
+++ b/webrecorder/webrecorder/templates/proxy_error.html
@@ -16,7 +16,7 @@ wbinfo.curr_browser = "{{ browser }}";
 </head>
 
 <body>
-<h2>Webrecorder Proxy Error</h2>
+<h2>{{ metadata.product }} Proxy Error</h2>
 {% if not err_body or status_code == 404 %}
 <p>Sorry, the url <b>{{ url }}</b> could not be loaded</p>
 {% elif status_code == 402 and err_body == 'Rate Limit' %}

--- a/webrecorder/webrecorder/templates/register.html
+++ b/webrecorder/webrecorder/templates/register.html
@@ -41,7 +41,7 @@
     {% else %}
 
     <div class="col-sm-8 col-md-6 col-md-offset-2">
-        <h2>Webrecorder Account Sign-Up</h2>
+        <h2>{{ metadata.product }} Account Sign-Up</h2>
 
         <h4>Create your own web archive as you browse!</h4>
         <br/>

--- a/webrecorder/webrecorder/templates/reporterror.html
+++ b/webrecorder/webrecorder/templates/reporterror.html
@@ -5,8 +5,8 @@
             <div class="modal-header">
                 <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
                 <h4>This Page Doesn't Look Right? Let Us Know!</h4>
-                <p>Some pages are tricky for Webrecorder to capture and replay. Our goal is to make it work as best as possible on any page!</p>
-                <p>Please indicate anything that may have gone wrong on this page. Your feedback will help make Webrecorder better!</p>
+                <p>Some pages are tricky for {{ metadata.product }} to capture and replay. Our goal is to make it work as best as possible on any page!</p>
+                <p>Please indicate anything that may have gone wrong on this page. Your feedback will help make {{ metadata.product }} better!</p>
             </div>
             <form method="post" action="/_reportissues" id="report-form">
                 <div class="modal-body">

--- a/webrecorder/webrecorder/templates/reset.html
+++ b/webrecorder/webrecorder/templates/reset.html
@@ -3,7 +3,7 @@
 {% block content %}
 <div class="row">
     <div class="col-sm-8 col-md-6 col-md-offset-2">
-    <h3>Webrecorder password reset</h3>
+    <h3>{{ metadata.product }} password reset</h3>
     <h4>Please enter a new password below:</h4>
     </div>
     

--- a/webrecorder/webrecorder/templates/upload_modal.html
+++ b/webrecorder/webrecorder/templates/upload_modal.html
@@ -4,7 +4,7 @@
             <div class="modal-content" style="padding-bottom: 40px">
                 <div class="modal-header">
                     <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
-                    <h4><span class="glyphicon glyphicon-button glyphicon-upload"></span>Upload Web Archive to Webrecorder</h4>
+                    <h4><span class="glyphicon glyphicon-button glyphicon-upload"></span>Upload Web Archive to {{ metadata.product }}</h4>
                 </div>
 
                 <div class="modal-body">


### PR DESCRIPTION
This pull updates some of the templates to use `{{ metadata.product }}` and `{{ get_app_host() }}` in place of `Webrecorder` and `webrecorder.io`, the same way other templates already do.

Caveats:

- I didn’t mess with FAQ, email templates, or terms of use, which all seem trickier to white label.
- I deleted branding.html, which I think is unused. Let me know if that’s wrong and I’ll undo.