### PR TITLE
extract + patch mode work (#351):

### DIFF
--- a/webrecorder/test/test_rec.py
+++ b/webrecorder/test/test_rec.py
@@ -60,6 +60,8 @@ class TestWebRecRecorder(FullStackTests):
         keys = self.redis.keys()
 
         assert set(keys) == set([
+            'h:defaults',
+            'h:roles',
             'r:USER:COLL:REC:warc',
             'r:USER:COLL:REC:cdxj',
             'r:USER:COLL:REC:info',
@@ -83,6 +85,8 @@ class TestWebRecRecorder(FullStackTests):
         keys = self.redis.keys()
 
         assert set(keys) == set([
+            'h:defaults',
+            'h:roles',
             'r:USER:COLL:REC:warc',
             'r:USER:COLL:REC2:warc',
             'r:USER:COLL:REC:cdxj',

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -1,6 +1,7 @@
 from bottle import request, HTTPError, redirect as bottle_redirect
 from functools import wraps
 from six.moves.urllib.parse import quote
+from webrecorder.utils import sanitize_tag, sanitize_title
 
 import re
 import os
@@ -8,10 +9,6 @@ import os
 
 # ============================================================================
 class BaseController(object):
-    ALPHA_NUM_RX = re.compile('[^\w-]')
-
-    WB_URL_COLLIDE = re.compile('^([\d]+([\w]{2}_)?|([\w]{2}_))$')
-
     def __init__(self, app, jinja_env, manager, config):
         self.app = app
         self.jinja_env = jinja_env
@@ -167,22 +164,10 @@ class BaseController(object):
         return decorator
 
     def sanitize_tag(self, tag):
-        id = tag.strip()
-        id = id.replace(' ', '-')
-        id = self.ALPHA_NUM_RX.sub('', id)
-        if self.WB_URL_COLLIDE.match(id):
-            id += '-'
-
-        return id
+        return sanitize_tag(tag)
 
     def sanitize_title(self, title):
-        id = title.lower().strip()
-        id = id.replace(' ', '-')
-        id = self.ALPHA_NUM_RX.sub('', id)
-        if self.WB_URL_COLLIDE.match(id):
-            id += '-'
-
-        return id
+        return sanitize_title(title)
 
     def get_view_user(self, user):
         return user

--- a/webrecorder/webrecorder/config/wr.yaml
+++ b/webrecorder/webrecorder/config/wr.yaml
@@ -54,7 +54,7 @@ url_templates:
     live: '{live_host}/live/resource/postreq?'
 
     record: '{record_host}/record/live/resource/postreq?param.user={user}&param.coll={coll}&param.rec={rec}&param.ip={ip}'
-    extract: '{record_host}/record/extract/resource/postreq?param.user={user}&param.coll={coll}&param.rec={rec}&param.ip={ip}&sources={sources}&param.recorder.patch_rec={patch_rec}'
+    extract: '{record_host}/record/extract/resource/postreq?param.user={user}&param.coll={coll}&param.rec={rec}&param.ip={ip}&sources={sources}&inv_sources={inv_sources}&param.recorder.patch_rec={patch_rec}'
     patch: '{record_host}/record/patch/resource/postreq?param.user={user}&param.coll={coll}&param.recorder.rec={rec}&param.rec=*&param.ip={ip}'
 
     snapshot: '{record_host}/record/live/resource/postreq?param.user={user}&param.coll={coll}&param.rec={rec}&put_record=resource'
@@ -158,7 +158,6 @@ tags_key: 'z:tags'
 user_tag_templ: 'r:{user}:{coll}:{rec}:tag:{tag}'
 
 ra_key: 'r:{user}:{coll}:{rec}:ra'
-replay_ra_key: 'r:{user}:{coll}:{rec}:ra-replay'
 
 user_usage_key: 'h:user-usage'
 temp_usage_key: 'h:temp-usage'

--- a/webrecorder/webrecorder/load/main.py
+++ b/webrecorder/webrecorder/load/main.py
@@ -70,7 +70,10 @@ def make_webagg():
                         warc_url,
                         cache_proxy_url)
 
-    extractor2 = GeventTimeoutAggregator(archives, timeout=timeout, invert_sources=True)
+    extractor2 = GeventTimeoutAggregator(archives, timeout=timeout,
+                                         sources_key='inv_sources',
+                                         invert_sources=True)
+
     extract_other = DefaultResourceHandler(
                         extractor2,
                         warc_url,

--- a/webrecorder/webrecorder/static/recordings.js
+++ b/webrecorder/webrecorder/static/recordings.js
@@ -870,6 +870,7 @@ var RouteTo = (function(){
         replayRecording: replayRecording,
         addToRecording: addToRecording,
         patchPage: patchPage,
+        extractPage: extractPage,
     }
 }());
 

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -2,6 +2,7 @@ from warcio.limitreader import LimitReader
 from pywb.webagg.utils import load_config
 from contextlib import contextmanager
 
+import re
 import gevent
 import logging
 
@@ -31,6 +32,31 @@ def init_logging():
 # ============================================================================
 def load_wr_config():
     return load_config('WR_CONFIG', 'pkg://webrecorder/config/wr.yaml', 'WR_USER_CONFIG', '')
+
+
+# ============================================================================
+ALPHA_NUM_RX = re.compile('[^\w-]')
+
+WB_URL_COLLIDE = re.compile('^([\d]+([\w]{2}_)?|([\w]{2}_))$')
+
+
+def sanitize_tag(tag):
+    id = tag.strip()
+    id = id.replace(' ', '-')
+    id = ALPHA_NUM_RX.sub('', id)
+    if WB_URL_COLLIDE.match(id):
+        id += '-'
+
+    return id
+
+def sanitize_title(title):
+    id = title.lower().strip()
+    id = id.replace(' ', '-')
+    id = ALPHA_NUM_RX.sub('', id)
+    if WB_URL_COLLIDE.match(id):
+        id += '-'
+
+    return id
 
 
 # ============================================================================


### PR DESCRIPTION
- create new patch recording in recorder only if needed (eg. loading from a secondary source)
- add 'extract_only' mode that only extracts, no patching
- use 'sources' and 'inv_sources' to specify secondary sources to patch
- utils: move sanitize_title/sanitize_tag to utils
- ui: fix typo, missing extractPage function
- config: remove unused key