### PR TITLE
Recorder fixes

### DIFF
--- a/webrecorder/test/test_rec.py
+++ b/webrecorder/test/test_rec.py
@@ -60,8 +60,6 @@ class TestWebRecRecorder(FullStackTests):
         keys = self.redis.keys()
 
         assert set(keys) == set([
-            'h:defaults',
-            'h:roles',
             'r:USER:COLL:REC:warc',
             'r:USER:COLL:REC:cdxj',
             'r:USER:COLL:REC:info',
@@ -85,8 +83,6 @@ class TestWebRecRecorder(FullStackTests):
         keys = self.redis.keys()
 
         assert set(keys) == set([
-            'h:defaults',
-            'h:roles',
             'r:USER:COLL:REC:warc',
             'r:USER:COLL:REC2:warc',
             'r:USER:COLL:REC:cdxj',

--- a/webrecorder/webrecorder/rec/storagecommitter.py
+++ b/webrecorder/webrecorder/rec/storagecommitter.py
@@ -68,6 +68,9 @@ class StorageCommitter(object):
         curr_user = None
 
         for user_dir in os.listdir(self.record_root_dir):
+            if self.is_temp(user_dir):
+                continue
+
             full_dir = os.path.join(self.record_root_dir, user_dir)
             if os.path.isdir(full_dir):
                 self.check_user(user_dir, full_dir)
@@ -83,9 +86,6 @@ class StorageCommitter(object):
             full_filename = os.path.join(full_dir, warcname)
 
             if self.is_locked(full_filename):
-                continue
-
-            if self.is_temp(user):
                 continue
 
             coll = None


### PR DESCRIPTION
- Fixes for issues caused by on-demand recording creation in recorder. Instead, create patch recording in app always.
- Use `no_dupe=True` to avoid creating duplicates instead of has_recording check
- StorageCommitter fix: skip temp user dirs right away
- ContentController:  add back `/$record/` route