### PR TITLE
rename fix: when renaming recording to name that already exists, ensu…

### DIFF
--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -5,6 +5,8 @@ from pywb.warcserver.test.testutils import TempDirTests, to_path
 
 import webtest
 import os
+import itertools
+import time
 
 from warcio.bufferedreaders import ChunkedDataReader
 from io import BytesIO
@@ -77,6 +79,19 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
     @classmethod
     def get_curr_dir(cls):
         return os.path.dirname(os.path.realpath(__file__))
+
+
+    @classmethod
+    def sleep_try(cls, sleep_interval, max_time, test_func):
+        max_count = float(max_time) / sleep_interval
+        for counter in itertools.count():
+            try:
+                time.sleep(sleep_interval)
+                test_func()
+                return
+            except:
+                if counter >= max_count:
+                    raise
 
 
 # ============================================================================

--- a/webrecorder/webrecorder/redisman.py
+++ b/webrecorder/webrecorder/redisman.py
@@ -441,8 +441,7 @@ class LoginManagerMixin(object):
             new_coll = new_coll_info['id']
 
         if rec != new_rec:
-            new_rec_info = self.create_recording(new_user, new_coll, new_rec, title,
-                                                 no_dupe=True)
+            new_rec_info = self.create_recording(new_user, new_coll, new_rec, title)
             title = new_rec_info['title']
             new_rec = new_rec_info['id']
 


### PR DESCRIPTION
…re a new recording is created (increment counter)

tests improvements:
- add tests for creating recording and collection with existing names
- add tests for renaming recording and collection to name of existing recording or collection
- wrap tests that need delay with new sleep_try() function, which sleeps repeatedly until test succeeds, up to max time