### PR TITLE
cache/access check improvements:

### DIFF
--- a/webrecorder/test/test_all_register_migrate.py
+++ b/webrecorder/test/test_all_register_migrate.py
@@ -113,12 +113,16 @@ class TestRegisterMigrate(FullStackTests):
         res = self.testapp.get('/someuser/test-migrate/abc/replay/mp_/http://httpbin.org/get?food=bar')
         res.charset = 'utf-8'
 
+        # no cache control setting here (only at collection replay)
+        assert 'Cache-Control' not in res.headers
         assert '"food": "bar"' in res.text, res.text
 
     def test_logged_in_replay_coll_1(self):
         res = self.testapp.get('/someuser/test-migrate/mp_/http://httpbin.org/get?food=bar')
         res.charset = 'utf-8'
 
+        # Cache-Control private to ignore cache
+        assert res.headers['Cache-Control'] == 'private'
         assert '"food": "bar"' in res.text, res.text
 
     def test_logged_in_coll_info(self):
@@ -212,9 +216,12 @@ class TestRegisterMigrate(FullStackTests):
         res.charset = 'utf-8'
         assert 'Example Domain' in res.text
 
-    def test_logged_in_replay_2(self):
+    def test_logged_in_replay_public(self):
         res = self.testapp.get('/someuser/new-coll/mp_/http://example.com/')
         res.charset = 'utf-8'
+
+        # no cache-control for public collections
+        assert 'Cache-Control' not in res.headers
         assert 'Example Domain' in res.text
 
     def test_logged_in_download(self):
@@ -240,6 +247,9 @@ class TestRegisterMigrate(FullStackTests):
     def test_logged_out_replay(self):
         res = self.testapp.get('/someuser/new-coll/mp_/http://example.com/')
         res.charset = 'utf-8'
+
+        # no cache-control for public collections
+        assert 'Cache-Control' not in res.headers
         assert 'Example Domain' in res.text
 
     def test_error_logged_out_download(self):

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -411,31 +411,38 @@ class ContentController(BaseController, RewriterApp):
             self.redir_set_session()
 
         remote_ip = None
+        frontend_cache_header = None
 
-        if type == 'replay' or type in self.MODIFY_MODES:
+        if type in self.MODIFY_MODES:
             if not self.manager.has_recording(user, coll, rec):
                 not_found = True
 
-            if type != 'replay':
-                self.manager.assert_can_write(user, coll)
+            self.manager.assert_can_write(user, coll)
 
-                if self.manager.is_out_of_space(user):
-                    raise HTTPError(402, 'Out of Space')
+            if self.manager.is_out_of_space(user):
+                raise HTTPError(402, 'Out of Space')
 
-                remote_ip = self._get_remote_ip()
+            remote_ip = self._get_remote_ip()
 
-                if self.manager.is_rate_limited(user, remote_ip):
-                    raise HTTPError(402, 'Rate Limit')
+            if self.manager.is_rate_limited(user, remote_ip):
+                raise HTTPError(402, 'Rate Limit')
 
-        if ((not_found or type == 'replay-coll') and
-            (not (self.manager.is_anon(user) and coll == 'temp')) and
-            (not self.manager.has_collection(user, coll))):
+        if type == 'replay-coll':
+            res = self.manager.has_collection_is_public(user, coll)
+            not_found = not res
+            if not_found:
+                self._redir_if_sanitized(self.sanitize_title(coll),
+                                         coll,
+                                         wb_url)
 
-            self._redir_if_sanitized(self.sanitize_title(coll),
-                                     coll,
-                                     wb_url)
+                raise HTTPError(404, 'No Such Collection')
 
-            raise HTTPError(404, 'No Such Collection')
+            if res != 'public':
+                frontend_cache_header = ('Cache-Control', 'private')
+
+        elif type == 'replay':
+            if not self.manager.has_recording(user, coll, rec):
+                not_found = True
 
         patch_rec = ''
 
@@ -485,6 +492,9 @@ class ContentController(BaseController, RewriterApp):
             resp = self.render_content(wb_url, kwargs, request.environ)
 
             self.add_csp_header(wb_url_obj, resp.status_headers)
+
+            if frontend_cache_header:
+                resp.status_headers.headers.append(frontend_cache_header)
 
             resp = HTTPResponse(body=resp.body,
                                 status=resp.status_headers.statusline,


### PR DESCRIPTION
- split _check_access() into check read and check write access
- check read access returns 'public' if read access is public, otherwise true/false
- for collection replay, add 'cache-control: private' to avoid cacheing at frontend, unless read access is 'public'
- anon user: better ensure access only to 'temp' collection, restrict adding duplicate 'temp' collections
- tests: update tests to check for 'cache-control: private' and no duplicate temp collections
- when adding auto-duplicate colls, ensure admin access for new collection to be added