### PR TITLE
recorder: enforce size limit while recording, don't write to WARC if …

### DIFF
--- a/webrecorder/test/test_all_register_migrate.py
+++ b/webrecorder/test/test_all_register_migrate.py
@@ -289,6 +289,8 @@ class TestRegisterMigrate(FullStackTests):
         assert '"rec": "test"' in res.text
 
     def test_logged_in_replay_2(self):
+        import time
+        time.sleep(0.1)
         res = self.testapp.get('/someuser/new-coll/move-test/replay/mp_/http://httpbin.org/get?rec=test')
         res.charset = 'utf-8'
         assert '"rec": "test"' in res.text

--- a/webrecorder/test/test_rec.py
+++ b/webrecorder/test/test_rec.py
@@ -42,6 +42,8 @@ class TestWebRecRecorder(FullStackTests):
 
         # Rec key must exist
         self.redis.hset('r:{user}:{coll}:{rec}:info'.format(user=user, coll=coll, rec=rec), 'id', rec)
+        self.redis.hset('u:{user}:info'.format(user=user), 'size', 0)
+        self.redis.hset('u:{user}:info'.format(user=user), 'max_size', 10000)
 
         req_url = '/record/live/resource/postreq?url={url}&param.recorder.user={user}&param.recorder.coll={coll}&param.recorder.rec={rec}'
         req_url = req_url.format(url=quote(url), user=user, coll=coll, rec=rec)


### PR DESCRIPTION
…new record will exceed the allotted size.

check for every response request before writing
update tests (add sleep to allot for gevent switch after recording)