### PR TITLE
config: Add ANON_DISABLED env config option to disable anonymous reco…

### DIFF
--- a/webrecorder/test/test_no_anon.py
+++ b/webrecorder/test/test_no_anon.py
@@ -1,0 +1,29 @@
+import os
+from .testutils import BaseWRTests
+import pytest
+
+
+# ============================================================================
+@pytest.fixture(params=['/record/http://example.com/',
+                        '/_new/foo/rec-sesh/record/http://example.com/',
+                        '/_new/foo/rec-sesh/record/mp_/http://example.com/',
+                        '/_new/temp/rec-sesh/extract/mp_/http://example.com/'])
+def url(request):
+    return request.param
+
+
+# ============================================================================
+class TestNoAnon(BaseWRTests):
+    @classmethod
+    def setup_class(cls):
+        os.environ['ANON_DISABLED'] = '1'
+        super(TestNoAnon, cls).setup_class()
+
+    def test_anon_rec_disabled(self, url):
+        res = self.testapp.get(url)
+        assert res.status_code == 302
+        assert res.headers['Location'] == 'http://localhost:80/'
+
+        res = res.follow()
+        assert 'anonymous recording is not available' in res.text
+        assert '<input>' not in res.text

--- a/webrecorder/test/test_no_anon.py
+++ b/webrecorder/test/test_no_anon.py
@@ -19,6 +19,11 @@ class TestNoAnon(BaseWRTests):
         os.environ['ANON_DISABLED'] = '1'
         super(TestNoAnon, cls).setup_class()
 
+    @classmethod
+    def teardown_class(cls):
+        super(TestNoAnon, cls).teardown_class()
+        os.environ['ANON_DISABLED'] = '0'
+
     def test_anon_rec_disabled(self, url):
         res = self.testapp.get(url)
         assert res.status_code == 302

--- a/webrecorder/test/test_record_limits.py
+++ b/webrecorder/test/test_record_limits.py
@@ -130,8 +130,6 @@ class TestRecordLimits(FullStackTests):
 
         time.sleep(0.1)
 
-        assert warc_size == os.path.getsize(warc_file)
-
         assert 0 == int(self.redis.hget(user_key, 'size'))
 
         assert len(self.redis.zrange('r:{user}:temp:rec:cdxj'.format(user=self.anon_user), 0, -1)) == 0

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -1,7 +1,7 @@
 from bottle import request, HTTPError, redirect as bottle_redirect
 from functools import wraps
 from six.moves.urllib.parse import quote
-from webrecorder.utils import sanitize_tag, sanitize_title
+from webrecorder.utils import sanitize_tag, sanitize_title, get_bool
 
 import re
 import os
@@ -18,6 +18,7 @@ class BaseController(object):
         self.app_host = os.environ['APP_HOST']
         self.content_host = os.environ['CONTENT_HOST']
         self.cache_template = config.get('cache_template')
+        self.anon_disabled = get_bool(os.environ.get('ANON_DISABLED'))
 
         self.init_routes()
 
@@ -99,6 +100,8 @@ class BaseController(object):
 
     def fill_anon_info(self, resp):
         sesh = self.get_session()
+
+        resp['anon_disabled'] = self.anon_disabled
 
         if sesh.is_anon():
             anon_user = sesh.anon_user

--- a/webrecorder/webrecorder/config/wr_sample.env
+++ b/webrecorder/webrecorder/config/wr_sample.env
@@ -8,6 +8,9 @@ DEFAULT_STORAGE=local
 # If false, users can register directly
 REQUIRE_INVITES=false
 
+# If set to true/1, anonymous recording is disabled
+ANON_DISABLED=false
+
 # Host settings
 # set to use specific host for content and app
 # recommended for security

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -12,6 +12,7 @@ from pywb.apps.rewriterapp import RewriterApp, UpstreamException
 
 from webrecorder.basecontroller import BaseController
 from webrecorder.load.wamloader import WAMLoader
+from webrecorder.utils import get_bool
 
 
 # ============================================================================
@@ -338,6 +339,11 @@ class ContentController(BaseController, RewriterApp):
         user = self.manager.get_curr_user()
 
         if not user:
+            if self.anon_disabled:
+                self.flash_message('Sorry, anonymous recording is not available.')
+                self.redirect('/')
+                return
+
             user = self.manager.get_anon_user(True)
             coll = 'temp'
             coll_title = 'Temporary Collection'

--- a/webrecorder/webrecorder/standalone/hooks/hook-webrecorder.py
+++ b/webrecorder/webrecorder/standalone/hooks/hook-webrecorder.py
@@ -46,5 +46,6 @@ datas += copy_metadata('bottle')
 hiddenimports = ['webrecorder.git_hash',
                  'pywb.git_hash',
                  'brotli',
+                 'configparser',
                  '_cffi_backend']
 

--- a/webrecorder/webrecorder/templates/index.html
+++ b/webrecorder/webrecorder/templates/index.html
@@ -43,9 +43,11 @@ var archives = {{ get_archives() | tojson }};
         {% include 'homepage_message.html' %}
     {% endif %}
 
+    {% if curr_user or not anon_disabled %}
     <div class="row top-buffer-lg bottom-buffer-lg">
         {% include 'homepage_recorder.html' %}
     </div>
+    {% endif %}
 
     {% if is_anon and invites_enabled %}
     <div class="row top-buffer">

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -60,6 +60,14 @@ def sanitize_title(title):
 
 
 # ============================================================================
+def get_bool(string):
+    if not string:
+        return False
+
+    return string.lower() not in ('0', 'false', 'f', 'off')
+
+
+# ============================================================================
 @contextmanager
 def redis_pipeline(redis_obj):
     p = redis_obj.pipeline(transaction=False)


### PR DESCRIPTION
…rding, fixes #213

setting ANON_DISABLE=1 or ANON_DISABLED=true will hide the recorder on the home page,
and prevent /record/ or /_new/ paths from starting an anonymous recording
tests: test_no_anon to test disabled anon