### PR TITLE
record size limit: ensure that payload content-length is computed for…

### DIFF
--- a/webrecorder/test/test_record_limits.py
+++ b/webrecorder/test/test_record_limits.py
@@ -41,6 +41,14 @@ class TestRecordLimits(FullStackTests):
         time.sleep(0.0)
         assert len(self.redis.zrange('r:{user}:temp:rec:cdxj'.format(user=self.anon_user), 0, -1)) == 1
 
+    def test_dont_record_2_chunked(self):
+        warc_file, warc_size, user_key, curr_size = self._get_info()
+
+        self.redis.hset(user_key, 'max_size', curr_size + 100)
+        res = self.testapp.get('/{user}/temp/rec/record/mp_/http://httpbin.org/stream-bytes/1300'.format(user=self.anon_user))
+
+        time.sleep(0.0)
+        assert len(self.redis.zrange('r:{user}:temp:rec:cdxj'.format(user=self.anon_user), 0, -1)) == 1
 
     def test_dont_record_will_exceed(self):
         warc_file, warc_size, user_key, curr_size = self._get_info()

--- a/webrecorder/webrecorder/rec/webrecrecorder.py
+++ b/webrecorder/webrecorder/rec/webrecrecorder.py
@@ -659,7 +659,12 @@ class SkipCheckingMultiFileWARCWriter(MultiFileWARCWriter):
 
         size = int(size or 0)
         max_size = int(max_size or 0)
-        length = int(resp.length or resp.rec_headers.get_header('Content-Length') or 0)
+
+        length = resp.length or resp.rec_headers.get_header('Content-Length')
+        if length is None:
+            self.ensure_digest(resp, block=True, payload=True)
+            resp.length = resp.payload_length
+            length = resp.length
 
         if size + length > max_size:
             print('New Record for {0} exceeds max size, not recording!'.format(params['url']))


### PR DESCRIPTION
… chunk-encoded responses to avoid exceeding size limit

tests: add test for recording a chunk-encoded response