### PR TITLE
list replay: add /user/coll/list/<list_id>/... as content replay route

### DIFF
--- a/webrecorder/test/test_lists_api.py
+++ b/webrecorder/test/test_lists_api.py
@@ -323,6 +323,26 @@ class TestListsAPI(FullStackTests):
         assert lists[1]['id'] == '1003'
         assert lists[1]['num_bookmarks'] == 2
 
+    # Record, then Replay Via List
+    # ========================================================================
+    def test_record_1(self):
+        res = self.testapp.get('/_new/temp/rec/record/mp_/http://example.com/')
+        assert res.status_code == 302
+        res = res.follow()
+        res.charset = 'utf-8'
+
+        assert 'Example Domain' in res.text
+
+    def test_replay_1(self):
+        res = self.testapp.get('/{user}/temp/list/1002/mp_/http://example.com/'.format(user=self.anon_user), status=200)
+        res.charset = 'utf-8'
+
+        assert 'Example Domain' in res.text
+
+        assert 'wbinfo.top_url = "http://localhost:80/{user}/temp/list/1002/http://example.com/"'.format(user=self.anon_user) in res.text, res.text
+
+    # Delete Collection
+    # ========================================================================
     def test_delete_coll(self):
         res = self.testapp.delete('/api/v1/collections/temp?user={user}'.format(user=self.anon_user))
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -270,7 +270,15 @@ class ContentController(BaseController, RewriterApp):
                                        inv_sources='*',
                                        redir_route='extract')
 
-        # Replay
+        # REPLAY
+        # Replay List
+        @self.app.route('/<user>/<coll>/list/<list_id>/<wb_url:path>', method='ANY')
+        def do_replay_rec(user, coll, list_id, wb_url):
+            request.path_shift(4)
+
+            return self.handle_routing(wb_url, user, coll, '*', type='replay-coll')
+
+        # Replay Recording
         @self.app.route('/<user>/<coll>/<rec>/replay/<wb_url:path>', method='ANY')
         def do_replay_rec(user, coll, rec, wb_url):
             request.path_shift(4)


### PR DESCRIPTION
Simply list replay endpoint, eg. `/user/coll/list/<list_id>/mp_/<url>`
- add tests to ensure top url contains `/user/coll/list/<list_id>/<url>`
- (note that url does not have to be bookmark in list)