### PR TITLE
API Tweaks: Optional lists and recordings, bulk list add

### DIFF
--- a/webrecorder/test/test_lists_api.py
+++ b/webrecorder/test/test_lists_api.py
@@ -310,6 +310,18 @@ class TestListsAPI(FullStackTests):
         assert res.json['lists'][0]['bookmarks'][1]['id'] == '104'
         assert res.json['lists'][0]['bookmarks'][1]['title'] == 'A New Title?'
 
+    def test_bulk_add_bookmarks(self):
+        bookmarks = [{'url': 'http://example.com/', 'title': 'Yet Another Example'},
+                     {'url': 'http://httpbin.org/', 'title': 'HttpBin.org'},
+                     {'url': 'http://test.example.com/foo', 'title': 'Just an example'}]
+
+        list_id = '1003'
+        res = self.testapp.post_json(self._format('/api/v1/list/%s/bulk_bookmarks?user={user}&coll=temp' % list_id),
+                                     params=bookmarks)
+
+
+        assert res.json['list']
+
     def test_coll_info_with_lists(self):
         res = self.testapp.get(self._format('/api/v1/collections/temp?user={user}'))
 
@@ -321,7 +333,7 @@ class TestListsAPI(FullStackTests):
         assert lists[0]['num_bookmarks'] == 4
 
         assert lists[1]['id'] == '1003'
-        assert lists[1]['num_bookmarks'] == 2
+        assert lists[1]['num_bookmarks'] == 5
 
     # Record, then Replay Via List
     # ========================================================================

--- a/webrecorder/test/test_lists_api.py
+++ b/webrecorder/test/test_lists_api.py
@@ -311,8 +311,8 @@ class TestListsAPI(FullStackTests):
         assert res.json['lists'][0]['bookmarks'][1]['title'] == 'A New Title?'
 
     def test_bulk_add_bookmarks(self):
-        bookmarks = [{'url': 'http://example.com/', 'title': 'Yet Another Example'},
-                     {'url': 'http://httpbin.org/', 'title': 'HttpBin.org'},
+        bookmarks = [{'url': 'http://example.com/', 'title': 'Yet Another Example', 'timestamp': '20161226000000'},
+                     {'url': 'http://httpbin.org/', 'title': 'HttpBin.org', 'timestamp': '201801020300000'},
                      {'url': 'http://test.example.com/foo', 'title': 'Just an example'}]
 
         list_id = '1003'

--- a/webrecorder/test/test_lists_api.py
+++ b/webrecorder/test/test_lists_api.py
@@ -341,6 +341,43 @@ class TestListsAPI(FullStackTests):
 
         assert 'wbinfo.top_url = "http://localhost:80/{user}/temp/list/1002/http://example.com/"'.format(user=self.anon_user) in res.text, res.text
 
+    # Collection and User Info
+    # ========================================================================
+    def test_colls_info(self):
+        res = self.testapp.get(self._format('/api/v1/collections?user={user}'))
+
+        assert len(res.json['collections']) == 1
+        assert res.json['collections'][0]['id'] == 'temp'
+
+        for coll in res.json['collections']:
+            assert coll['lists']
+            assert coll['recordings']
+
+        res = self.testapp.get(self._format('/api/v1/collections?user={user}&include_lists=false&include_recordings=false'))
+
+        for coll in res.json['collections']:
+            assert 'lists' not in coll
+            assert 'recordings' not in coll
+
+        res = self.testapp.get(self._format('/api/v1/collections?user={user}&include_lists=0&include_recordings=1'))
+
+        for coll in res.json['collections']:
+            assert 'lists' not in coll
+            assert 'recordings' in coll
+
+    def test_user_info(self):
+        res = self.testapp.get(self._format('/api/v1/users/{user}?include_colls=true'))
+
+        user = res.json['user']
+
+        assert len(user['collections']) == 1
+        assert user['collections'][0]['id'] == 'temp'
+
+        for coll in user['collections']:
+            assert 'lists' not in coll
+            assert 'recordings' not in coll
+
+
     # Delete Collection
     # ========================================================================
     def test_delete_coll(self):

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -73,9 +73,7 @@ class TestListsAPIAccess(FullStackTests):
         self.pub_list_priv_coll = self._create_list('test', coll_name, 'Public List', public=True)
 
     def test_logout_login_user_2(self):
-        res = self.testapp.get('/api/v1/logout')
-
-        assert res.headers['Location'] == 'http://localhost:80/'
+        res = self.testapp.get('/api/v1/logout', status=200)
 
         params = {'username': 'another',
                   'password': 'TestTest456',
@@ -102,6 +100,16 @@ class TestListsAPIAccess(FullStackTests):
 
         assert len(self.redis.keys('l:*:info')) == 4
         assert len(self.redis.keys('b:*:info')) == 4
+
+    def test_no_lists_user_info(self):
+        # wrong user
+        res = self.testapp.get('/api/v1/users/test', status=404)
+
+        res = self.testapp.get('/api/v1/users/another')
+
+        assert len(res.json['user']['collections']) == 2
+        for coll in res.json['user']['collections']:
+            assert 'lists' not in coll
 
     def test_public_list_private_coll_error_logged_in(self):
         res = self.testapp.get('/api/v1/lists?user=test&coll=some-coll', status=404)

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -56,9 +56,16 @@ class CollsController(BaseController):
         def get_collections():
             user = self.get_user(api=True, redir_check=False)
 
+            kwargs = {}
+            if request.query.include_recordings:
+                kwargs['include_recordings'] = request.query.include_lists == 'true'
+
+            if request.query.include_lists:
+                kwargs['include_lists'] = request.query.include_lists == 'true'
+
             collections = user.get_collections()
 
-            return {'collections': [coll.serialize() for coll in collections]}
+            return {'collections': [coll.serialize(**kwargs) for coll in collections]}
 
         @self.app.get('/api/v1/collections/<coll_name>')
         def get_collection(coll_name):

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -5,6 +5,7 @@ from webrecorder.basecontroller import BaseController
 from webrecorder.webreccork import ValidationException
 
 from webrecorder.models.base import DupeNameException
+from webrecorder.utils import get_bool
 
 
 # ============================================================================
@@ -56,12 +57,9 @@ class CollsController(BaseController):
         def get_collections():
             user = self.get_user(api=True, redir_check=False)
 
-            kwargs = {}
-            if request.query.include_recordings:
-                kwargs['include_recordings'] = request.query.include_lists == 'true'
-
-            if request.query.include_lists:
-                kwargs['include_lists'] = request.query.include_lists == 'true'
+            kwargs = {'include_recordings': get_bool(request.query.get('include_recordings', 'true')),
+                      'include_lists': get_bool(request.query.get('include_lists', 'true'))
+                     }
 
             collections = user.get_collections()
 

--- a/webrecorder/webrecorder/listscontroller.py
+++ b/webrecorder/webrecorder/listscontroller.py
@@ -89,6 +89,17 @@ class ListsController(BaseController):
 
             return {'bookmark': bookmark.serialize()}
 
+        @self.app.post('/api/v1/list/<list_id>/bulk_bookmarks')
+        def create_bookmarks(list_id):
+            user, collection, blist = self.load_user_coll_list(list_id)
+
+            bookmark_list = request.json
+
+            for bookmark_data in bookmark_list:
+                bookmark = blist.create_bookmark(bookmark_data)
+
+            return {'list': blist.serialize()}
+
         @self.app.get('/api/v1/list/<list_id>/bookmarks')
         def get_bookmarks(list_id):
             user, collection, blist = self.load_user_coll_list(list_id)

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -210,14 +210,16 @@ class Collection(RedisOrderedListMixin, RedisNamedContainer):
 
         return sorted(pagelist, key=lambda x: x['timestamp'])
 
-    def serialize(self):
+    def serialize(self, include_recordings=True, include_lists=True):
         data = super(Collection, self).serialize()
 
-        recordings = self.get_recordings(load=True)
-        data['recordings'] = [recording.serialize() for recording in recordings]
+        if include_recordings:
+            recordings = self.get_recordings(load=True)
+            data['recordings'] = [recording.serialize() for recording in recordings]
 
-        lists = self.get_lists(load=True)
-        data['lists'] = [blist.serialize(include_bookmarks=False) for blist in lists]
+        if include_lists:
+            lists = self.get_lists(load=True)
+            data['lists'] = [blist.serialize(include_bookmarks=False) for blist in lists]
 
         return data
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -128,7 +128,7 @@ class Bookmark(RedisUniqueComponent):
         key = self.INFO_KEY.format(book=bid)
 
         self.data = {'url': props['url'],
-                     'timestamp': props['timestamp'],
+                     'timestamp': props.get('timestamp', ''),
                      'title': props['title'],
                      'state': '0',
                      'owner': self.owner.my_id,

--- a/webrecorder/webrecorder/models/user.py
+++ b/webrecorder/webrecorder/models/user.py
@@ -186,7 +186,9 @@ class User(RedisNamedContainer):
 
         if include_colls:
             colls = self.get_collections()
-            data['collections'] = [coll.serialize() for coll in colls]
+            data['collections'] = [coll.serialize(
+                                    include_recordings=False,
+                                    include_lists=False) for coll in colls]
 
         data['username'] = self.name
 

--- a/webrecorder/webrecorder/models/user.py
+++ b/webrecorder/webrecorder/models/user.py
@@ -171,7 +171,11 @@ class User(RedisNamedContainer):
     def is_anon(self):
         return self.name.startswith('temp-')
 
-    def serialize(self, compute_size_allotment=False, include_colls=False):
+    def serialize(self, compute_size_allotment=False,
+                  include_colls=False,
+                  include_recordings=False,
+                  include_lists=False):
+
         data = super(User, self).serialize()
 
         # assemble space usage
@@ -187,8 +191,8 @@ class User(RedisNamedContainer):
         if include_colls:
             colls = self.get_collections()
             data['collections'] = [coll.serialize(
-                                    include_recordings=False,
-                                    include_lists=False) for coll in colls]
+                                    include_recordings=include_recordings,
+                                    include_lists=include_lists) for coll in colls]
 
         data['username'] = self.name
 

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -102,7 +102,7 @@ class UserController(BaseController):
         @self.user_manager.auth_view()
         def logout():
             self.user_manager.logout()
-            self.redirect('/')
+            return {'message': 'Sucessefully logged out'}
 
         # PASSWORD
         @self.app.post('/api/v1/updatepassword')

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -133,7 +133,6 @@ class UserController(BaseController):
 
 
         @self.app.get(['/api/v1/users/<username>', '/api/v1/users/<username>/'])
-        @self.user_manager.auth_view()
         def api_get_user(username):
             """API enpoint to return user info"""
 


### PR DESCRIPTION
Various API tweaks:
- `include_lists` and `include_recordings` query params for `/api/v1/collections` endpoint
- `/api/v1/users/<user>` endpoint does not include recordings or lists
- `/api/v1/users/<user>` endpoint supported for current temp user (and only for current user or admin)
- `/api/v1/logout` returns JSON instead of redirecting
- `/api/v1/list/<list_id>/bulk_bookmarks` POST endpoint to add bookmarks in bulk (as a JSON list)
- update tests for API changes
