### PR TITLE
API Work

### DIFF
--- a/webrecorder/test/test_anon_workflow.py
+++ b/webrecorder/test/test_anon_workflow.py
@@ -179,7 +179,7 @@ class TestTempContent(FullStackTests):
 
         # Add as page
         page = {'title': 'Example Title', 'url': 'http://httpbin.org/get?food=bar', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/my-recording/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
+        res = self.testapp.post_json('/api/v1/recordings/my-recording/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
 
         assert res.json == {}
 
@@ -244,7 +244,7 @@ class TestTempContent(FullStackTests):
 
         # Add as page
         page = {'title': 'Example Title', 'url': 'http://httpbin.org/get?bood=far', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/my-rec2/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
+        res = self.testapp.post_json('/api/v1/recordings/my-rec2/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
 
         assert res.json == {}
 
@@ -271,7 +271,7 @@ class TestTempContent(FullStackTests):
 
         # Add as page
         page = {'title': 'Example Title', 'url': 'http://httpbin.org/get?good=far', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/my-recording-2/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
+        res = self.testapp.post_json('/api/v1/recordings/my-recording-2/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
 
         assert res.json == {}
 
@@ -297,7 +297,7 @@ class TestTempContent(FullStackTests):
 
         # Add as page
         page = {'title': 'вэбрекордэр!', 'url': test_url, 'ts': '2016010203000000'}
-        res = self.testapp.post(
+        res = self.testapp.post_json(
             '/api/v1/recordings/{rec}/pages?user={user}&coll=temp'.format(rec=quote('вэбрекордэр'), user=self.anon_user),
             params=page
         )
@@ -342,7 +342,7 @@ class TestTempContent(FullStackTests):
 
         # Add as page
         page = {'title': 'Special char test', 'url': test_url, 'ts': '2016010203000000'}
-        res = self.testapp.post(
+        res = self.testapp.post_json(
             '/api/v1/recordings/{rec}/pages?user={user}&coll=temp'.format(rec='test--ok', user=self.anon_user),
             params=page
         )
@@ -375,7 +375,7 @@ class TestTempContent(FullStackTests):
 
         # Add as page
         page = {'title': 'HTML formatting test', 'url': test_url, 'ts': '2016010203000000'}
-        res = self.testapp.post(
+        res = self.testapp.post_json(
             '/api/v1/recordings/{rec}/pages?user={user}&coll=temp'.format(rec='emmyem-test-recording', user=self.anon_user),
             params=page
         )
@@ -507,7 +507,7 @@ class TestTempContent(FullStackTests):
         cdx[4]['mime'] = '-'
 
     def _test_rename_rec(self):
-        res = self.testapp.post('/api/v1/recordings/my-rec2/rename/My%20Recording?user={user}&coll=temp'.format(user=self.anon_user))
+        res = self.testapp.post_json('/api/v1/recordings/my-rec2/rename/My%20Recording?user={user}&coll=temp'.format(user=self.anon_user))
 
         assert res.json == {'rec_id': 'my-recording-3', 'coll_id': 'temp'}
 

--- a/webrecorder/test/test_anon_workflow.py
+++ b/webrecorder/test/test_anon_workflow.py
@@ -539,11 +539,15 @@ class TestTempContent(FullStackTests):
         self._assert_rec_keys(self.anon_user, 'temp', all_recs)
 
 
-    def test_anon_delete_recs(self):
+    def test_anon_coll_info(self):
         res = self.testapp.get('/api/v1/collection/temp?user={user}'.format(user=self.anon_user))
         recs = res.json['collection']['recordings']
         assert set([rec['id'] for rec in recs]) == set(['my-recording', 'my-recording-2', 'my-rec2', 'вэбрекордэр', 'test--ok', 'emmyem-test-recording'])
 
+        assert res.json['collection']['timespan'] >= 0
+        assert res.json['collection']['duration'] >= 0
+
+    def test_anon_delete_recs(self):
         res = self.testapp.delete('/api/v1/recordings/my-recording?user={user}&coll=temp'.format(user=self.anon_user))
 
         assert res.json == {'deleted_id': 'my-recording'}

--- a/webrecorder/test/test_api_user_login.py
+++ b/webrecorder/test/test_api_user_login.py
@@ -22,7 +22,7 @@ class TestApiUserLogin(FullStackTests):
         assert self.ISO_DT_RX.match(user['created_at'])
         assert self.ISO_DT_RX.match(user['updated_at'])
 
-        assert set(user.keys()) == {'id', 'username', 'created_at', 'updated_at', 'space_utilization', 'ttl', 'max_size', 'size'}
+        assert set(user.keys()) == {'id', 'username', 'created_at', 'updated_at', 'space_utilization', 'ttl', 'max_size', 'size', 'timespan'}
 
     def test_api_register_fail_mismatch_password(self):
         # mismatch password

--- a/webrecorder/test/test_auto_login.py
+++ b/webrecorder/test/test_auto_login.py
@@ -38,7 +38,7 @@ class TestAutoLogin(FullStackTests):
 
         # Add as page
         page = {'title': 'Example Title', 'url': 'http://httpbin.org/get?food=bar', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/rec-sesh/pages?user=test&coll=default-collection', params=page)
+        res = self.testapp.post_json('/api/v1/recordings/rec-sesh/pages?user=test&coll=default-collection', params=page)
 
         assert res.json == {}
 

--- a/webrecorder/test/test_auto_login.py
+++ b/webrecorder/test/test_auto_login.py
@@ -46,5 +46,32 @@ class TestAutoLogin(FullStackTests):
         res = self.testapp.get('/api/v1/curr_user')
         assert res.json == {'curr_user': 'test'}
 
+    def test_get_collection(self):
+        res = self.testapp.get('/api/v1/collection/default-collection?user=test')
+
+        assert res.json['collection']
+        coll = res.json['collection']
+
+        assert coll['public_index'] == True
+        assert coll['public'] == False
+        assert coll['title'] == 'Default Collection'
+        assert 'This is your first collection' in coll['desc']
+
+    def test_update_collection(self):
+        params = {'desc': 'New Description',
+                  'public_index': False,
+                  'public': True,
+                  'title': 'New Title'
+                 }
+
+        res = self.testapp.post_json('/api/v1/collection/default-collection?user=test', params=params)
+
+        assert res.json['collection']
+        coll = res.json['collection']
+
+        assert coll['public_index'] == False
+        assert coll['public'] == True
+        assert coll['title'] == 'New Title'
+        assert coll['desc'] == 'New Description'
 
 

--- a/webrecorder/test/test_cdxj_cache.py
+++ b/webrecorder/test/test_cdxj_cache.py
@@ -59,6 +59,9 @@ class TestCDXJCache(FullStackTests):
         self.sleep_try(0.1, 1.0, self.assert_exists(REC_CDXJ, True))
 
     def test_record_2(self):
+        # ensure duration of at least 1 sec
+        time.sleep(1.0)
+
         res = self.testapp.get('/' + self.anon_user + '/temp/rec/record/mp_/http://httpbin.org/get?bood=far')
         res.charset = 'utf-8'
 
@@ -133,6 +136,12 @@ class TestCDXJCache(FullStackTests):
 
         assert load_counter == 1
 
+    def test_check_duration(self):
+        res = self.testapp.get('/api/v1/collection/temp?user={user}'.format(user=self.anon_user))
+
+        assert res.json['collection']['duration'] > 0
+        assert res.json['collection']['timespan'] > 0
+
     def test_ensure_all_files_delete(self):
         user_dir = os.path.join(self.warcs_dir, self.anon_user)
         files = os.listdir(user_dir)
@@ -152,5 +161,10 @@ class TestCDXJCache(FullStackTests):
             assert not os.path.isdir(self.storage_today)
 
         self.sleep_try(0.1, 10.0, assert_deleted)
+
+    def test_user_timespan(self):
+        res = self.testapp.get('/api/v1/users/' + self.anon_user)
+        # modified after delete, should have taken more than 2 seconds to get here
+        assert res.json['user']['timespan'] > 2
 
 

--- a/webrecorder/test/test_colls_api.py
+++ b/webrecorder/test/test_colls_api.py
@@ -10,7 +10,7 @@ class TestWebRecCollsAPI(BaseWRTests):
         super(TestWebRecCollsAPI, cls).setup_class()
 
     def test_create_anon_coll(self):
-        res = self.testapp.post('/api/v1/collections?user={user}'.format(user=self.anon_user), params={'title': 'Temp'})
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), params={'title': 'Temp'})
 
         assert self.testapp.cookies['__test_sesh'] != ''
 
@@ -18,8 +18,8 @@ class TestWebRecCollsAPI(BaseWRTests):
         assert res.json['collection']['title'] == 'Temp'
 
     def test_create_anon_coll_dup_error(self):
-        res = self.testapp.post('/api/v1/collections?user={user}'.format(user=self.anon_user),
-                                params={'title': 'Temp'})
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user),
+                                     params={'title': 'Temp'})
 
         assert self.testapp.cookies['__test_sesh'] != ''
 
@@ -59,15 +59,15 @@ class TestWebRecCollsAPI(BaseWRTests):
         assert res.json == {'error_message': 'No such collection'}
 
     def test_error_missing_user_coll(self):
-        res = self.testapp.post('/api/v1/collections', params={'title': 'Recording'}, status=400)
+        res = self.testapp.post_json('/api/v1/collections', params={'title': 'Recording'}, status=400)
         assert res.json == {'error_message': "User must be specified", 'request_data': {'title': 'Recording'}}
 
     def test_error_invalid_user_coll(self):
-        res = self.testapp.post('/api/v1/collections?user=user', params={'title': 'Example'}, status=404)
+        res = self.testapp.post_json('/api/v1/collections?user=user', params={'title': 'Example'}, status=404)
         assert res.json == {"error_message": "No such user", 'request_data': {'title': 'Example'}}
 
     def test_error_invalid_user_coll_2(self):
-        res = self.testapp.post('/api/v1/collections?user=temp$123', params={'title': 'Example'}, status=404)
+        res = self.testapp.post_json('/api/v1/collections?user=temp$123', params={'title': 'Example'}, status=404)
         assert res.json == {"error_message": "No such user", 'request_data': {'title': 'Example'}}
 
     def test_delete_coll(self):

--- a/webrecorder/test/test_colls_api.py
+++ b/webrecorder/test/test_colls_api.py
@@ -40,6 +40,8 @@ class TestWebRecCollsAPI(BaseWRTests):
         assert self.ISO_DT_RX.match(coll['updated_at'])
 
         assert coll['recordings'] == []
+        assert coll['public'] == False
+        assert coll['public_index'] == True
 
     def test_list_anon_collections(self):
         res = self.testapp.get('/api/v1/collections?user={user}'.format(user=self.anon_user))

--- a/webrecorder/test/test_extract.py
+++ b/webrecorder/test/test_extract.py
@@ -69,21 +69,31 @@ class TestExtractContent(FullStackTests):
         # Extract Test
         assert recs['extract-test']['desc'] == 'Extract Test'
         assert recs['extract-test']['ra_sources'] == ['ia']
+        assert recs['extract-test']['duration'] >= 0
 
         # empty patch
         assert recs['patch-of-extract-test']['size'] == 0
         assert recs['patch-of-extract-test']['desc'] == 'patch-of-extract-test'
         assert recs['patch-of-extract-test']['rec_type'] == 'patch'
+        assert recs['patch-of-extract-test']['duration'] >= 0
 
         # Extract Test 2
         assert recs['extract-test-2']['desc'] == 'Extract Test'
         assert recs['extract-test-2']['ra_sources'] == ['ia']
+        assert recs['extract-test-2']['duration'] >= 0
 
         # empty patch
         assert recs['patch-of-extract-test-2']['size'] == 0
         assert recs['patch-of-extract-test-2']['desc'] == 'patch-of-extract-test-2'
         assert recs['patch-of-extract-test-2']['rec_type'] == 'patch'
+        assert recs['patch-of-extract-test-2']['duration'] >= 0
 
         # Extract Only Test
         assert recs['extract-only-test']['desc'] == 'Extract Only Test'
         assert recs['extract-only-test']['ra_sources'] == ['ia']
+        assert recs['extract-only-test']['duration'] >= 0
+
+        # at least 1 second has expired
+        assert res.json['collection']['timespan'] >= 0
+        assert res.json['collection']['duration'] >= 0
+

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -5,7 +5,7 @@ from webrecorder.models.list_bookmarks import BookmarkList, Bookmark
 
 
 # ============================================================================
-class TestListsAPI(FullStackTests):
+class TestListsAnonUserAPI(FullStackTests):
     def _format(self, url):
         return url.format(user=self.anon_user)
 
@@ -36,7 +36,7 @@ class TestListsAPI(FullStackTests):
 
         _coll, _ = self.get_coll_rec(self.anon_user, 'temp', '')
 
-        TestListsAPI.coll = _coll
+        TestListsAnonUserAPI.coll = _coll
 
         self.redis.set(BookmarkList.COUNTER_KEY, 1000)
         self.redis.set(Bookmark.COUNTER_KEY, 100)
@@ -78,12 +78,14 @@ class TestListsAPI(FullStackTests):
 
         assert res.json['list']['id'] == '1003'
         assert res.json['list']['title'] == 'Another List'
+        assert res.json['list']['public'] == False
 
     def test_get_list(self):
         res = self.testapp.get(self._format('/api/v1/list/1002?user={user}&coll=temp'))
 
         assert res.json['list']['id'] == '1002'
         assert res.json['list']['title'] == 'New List'
+        assert res.json['list']['public'] == False
 
     def test_list_all_lists(self):
         res = self.testapp.get(self._format('/api/v1/lists?user={user}&coll=temp'))
@@ -347,13 +349,17 @@ class TestListsAPI(FullStackTests):
 
         lists = res.json['collection']['lists']
 
-        assert len(lists) == 2
+        # only public lists included
+        assert len(lists) == 1
 
         assert lists[0]['id'] == '1002'
-        assert lists[0]['num_bookmarks'] == 4
+        assert lists[0]['total_bookmarks'] == 4
 
-        assert lists[1]['id'] == '1003'
-        assert lists[1]['num_bookmarks'] == 5
+        # only first bookmark loaded
+        assert len(lists[0]['bookmarks']) == 1
+
+        #assert lists[1]['id'] == '1003'
+        #assert lists[1]['total_bookmarks'] == 5
 
     # Record, then Replay Via List
     # ========================================================================

--- a/webrecorder/test/test_lists_api.py
+++ b/webrecorder/test/test_lists_api.py
@@ -57,7 +57,9 @@ class TestListsAPI(FullStackTests):
         assert blist['owner'] == self.coll
         assert blist['id'] == '1001'
         assert blist['desc'] == 'List Description Goes Here!'
-        assert blist['public'] == '0'
+        assert blist['public'] == False
+
+        assert self.redis.hget('l:1001:info', 'public') == '0'
 
         assert self.redis.get(BookmarkList.COUNTER_KEY) == '1001'
 
@@ -196,6 +198,19 @@ class TestListsAPI(FullStackTests):
         assert blist['created_at'] < blist['updated_at']
 
         assert self.ISO_DT_RX.match(blist['updated_at'])
+
+    def test_update_list_public(self):
+        params = {'public': True}
+
+        res = self.testapp.post_json(self._format('/api/v1/list/1002?user={user}&coll=temp'), params=params)
+
+        blist = res.json['list']
+        assert blist['title'] == 'A List'
+        assert blist['id'] == '1002'
+        assert blist['public'] == True
+
+        assert self.redis.hget('l:1002:info', 'public') == '1'
+
 
     # Bookmarks
     # ========================================================================

--- a/webrecorder/test/test_lists_api.py
+++ b/webrecorder/test/test_lists_api.py
@@ -27,7 +27,7 @@ class TestListsAPI(FullStackTests):
         return res
 
     def test_create_anon_coll(self):
-        res = self.testapp.post(self._format('/api/v1/collections?user={user}'), params={'title': 'Temp'})
+        res = self.testapp.post_json(self._format('/api/v1/collections?user={user}'), params={'title': 'Temp'})
 
         assert self.testapp.cookies['__test_sesh'] != ''
 

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -30,7 +30,7 @@ class TestListsAPIAccess(FullStackTests):
 
         coll_name = sanitize_title(coll_title)
 
-        res = self.testapp.post('/api/v1/collections?user={0}'.format(user), params=params)
+        res = self.testapp.post_json('/api/v1/collections?user={0}'.format(user), params=params)
         assert res.json['collection']
 
         return coll_name

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -116,6 +116,15 @@ class TestListsAPIAccess(FullStackTests):
         for coll in res.json['user']['collections']:
             assert 'lists' not in coll
 
+    def test_set_featured_list(self):
+        params = {'featured_list': self.priv_list_priv_coll}
+        res = self.testapp.post_json('/api/v1/collection/some-coll?user=another', params=params, status=400)
+        assert res.json['error'] == 'no_such_list'
+
+        params = {'featured_list': self.pub_list_pub_coll}
+        res = self.testapp.post_json('/api/v1/collection/some-coll?user=another', params=params)
+        assert res.json['collection']['featured_list'] == self.pub_list_pub_coll
+
     def test_public_list_private_coll_error_logged_in(self):
         res = self.testapp.get('/api/v1/lists?user=test&coll=some-coll', status=404)
 
@@ -132,6 +141,7 @@ class TestListsAPIAccess(FullStackTests):
         res = self.testapp.get('/api/v1/collection/some-coll?user=another')
         assert len(res.json['collection']['lists']) == 1
         assert res.json['collection']['lists'][0]['title'] == 'Public List'
+        assert res.json['collection']['featured_list'] == self.pub_list_pub_coll
 
     def test_get_list_by_id_logged_out(self):
         res = self.testapp.get('/api/v1/list/{0}?user=another&coll=some-coll'.format(self.priv_list_pub_coll), status=404)
@@ -160,6 +170,7 @@ class TestListsAPIAccess(FullStackTests):
         res = self.testapp.get('/api/v1/collection/some-coll?user=another')
         assert len(res.json['collection']['lists']) == 1
         assert res.json['collection']['lists'][0]['title'] == 'Public List'
+        assert res.json['collection']['featured_list'] == self.pub_list_pub_coll
 
     def test_get_list_by_id_logged_in_diff_user(self):
         res = self.testapp.get('/api/v1/list/{0}?user=another&coll=some-coll'.format(self.priv_list_pub_coll), status=404)

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -26,12 +26,17 @@ class TestListsAPIAccess(FullStackTests):
     def _create_coll(self, user, coll_title, public=False):
         # Collection
         params = {'title': coll_title,
-                  'public': 'on' if public else 'off'}
+                  'public': public}
 
         coll_name = sanitize_title(coll_title)
 
         res = self.testapp.post_json('/api/v1/collections?user={0}'.format(user), params=params)
-        assert res.json['collection']
+        collection = res.json['collection']
+
+        if public:
+            assert collection['r:@public'] == '1'
+        else:
+            assert 'r:@public' not in collection
 
         return coll_name
 

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -51,6 +51,7 @@ class TestListsAPIAccess(FullStackTests):
 
         assert res.json['list']
         list_id = res.json['list']['id']
+        assert res.json['list']['public'] == public
 
         # Bookmark
         params = {'title': 'A Bookmark',

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -33,10 +33,7 @@ class TestListsAPIAccess(FullStackTests):
         res = self.testapp.post_json('/api/v1/collections?user={0}'.format(user), params=params)
         collection = res.json['collection']
 
-        if public:
-            assert collection['r:@public'] == '1'
-        else:
-            assert 'r:@public' not in collection
+        assert collection['public'] == public
 
         return coll_name
 

--- a/webrecorder/test/test_patch.py
+++ b/webrecorder/test/test_patch.py
@@ -23,7 +23,7 @@ class TestPatchContent(FullStackTests):
 
         # Add as page
         page = {'title': 'Example Title', 'url': 'http://httpbin.org/get?food=bar', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/new-patch/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
+        res = self.testapp.post_json('/api/v1/recordings/new-patch/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
 
         assert res.json == {}
 

--- a/webrecorder/test/test_recs_api.py
+++ b/webrecorder/test/test_recs_api.py
@@ -12,7 +12,7 @@ class TestWebRecRecAPI(FullStackTests):
         assert self.redis.exists('r:' + rec + ':info')
 
     def test_create_anon_coll(self):
-        res = self.testapp.post('/api/v1/collections?user={user}'.format(user=self.anon_user), params={'title': 'Temp'})
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), params={'title': 'Temp'})
 
         assert self.testapp.cookies['__test_sesh'] != ''
 

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -33,7 +33,7 @@ class TestRegisterMigrate(FullStackTests):
             all_closed = True
 
         with patch('webrecorder.rec.webrecrecorder.SkipCheckingMultiFileWARCWriter.close_file', close_file):
-            res = self.testapp.post(url)
+            res = self.testapp.post_json(url)
 
             def assert_move():
                 assert all_closed == True
@@ -54,7 +54,7 @@ class TestRegisterMigrate(FullStackTests):
 
         # Add as page
         page = {'title': 'Example Title', 'url': 'http://httpbin.org/get?food=bar', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/abc/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
+        res = self.testapp.post_json('/api/v1/recordings/abc/pages?user={user}&coll=temp'.format(user=self.anon_user), params=page)
 
         assert res.json == {}
 
@@ -405,23 +405,23 @@ class TestRegisterMigrate(FullStackTests):
 
     def test_error_logged_out_download(self):
         res = self.testapp.get('/someuser/new-coll/$download', status=404)
-        assert 'No such page' in res.text
+        assert res.json == {'error': 'not_found'}
 
     def test_error_logged_out_no_coll(self):
         res = self.testapp.get('/someuser/test-migrate', status=404)
-        assert 'No such page' in res.text
+        assert res.json == {'error': 'not_found'}
 
     def test_error_logged_out_record(self):
         res = self.testapp.get('/someuser/new-coll/move-test/record/mp_/http://example.com/', status=404)
-        assert 'No such page' in res.text
+        assert res.json == {'error': 'not_found'}
 
     def test_error_logged_out_patch(self):
         res = self.testapp.get('/someuser/new-coll/move-test/patch/mp_/http://example.com/', status=404)
-        assert 'No such page' in res.text
+        assert res.json == {'error': 'not_found'}
 
     def test_error_logged_out_replay_coll_1(self):
         res = self.testapp.get('/someuser/test-migrate/mp_/http://httpbin.org/get?food=bar', status=404)
-        assert 'No such page' in res.text
+        assert res.json == {'error': 'not_found'}
 
     def test_login(self):
         params = {'username': 'someuser',
@@ -436,7 +436,7 @@ class TestRegisterMigrate(FullStackTests):
         assert self.testapp.cookies.get('__test_sesh', '') != ''
 
     def _test_rename_rec(self):
-        res = self.testapp.post('/api/v1/recordings/abc/rename/FOOD%20BAR?user=someuser&coll=test-migrate')
+        res = self.testapp.post_json('/api/v1/recordings/abc/rename/FOOD%20BAR?user=someuser&coll=test-migrate')
 
         assert res.json == {'rec_id': 'food-bar', 'coll_id': 'test-migrate'}
 
@@ -576,7 +576,7 @@ class TestRegisterMigrate(FullStackTests):
 
     def test_different_user_replay_private_error(self):
         res = self.testapp.get('/someuser/test-migrate/mp_/http://httpbin.org/get?food=bar', status=404)
-        assert 'No such page' in res.text
+        assert res.json == {'error': 'not_found'}
 
     def test_logout_3(self):
         res = self.testapp.get('/_logout')

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -61,7 +61,7 @@ class TestUpload(FullStackTests):
 
         # Add as page
         page = {'title': 'Example Title', 'url': 'http://httpbin.org/get?food=bar', 'ts': '2016010203000000'}
-        res = self.testapp.post('/api/v1/recordings/rec-sesh/pages?user=test&coll=default-collection', params=page)
+        res = self.testapp.post_json('/api/v1/recordings/rec-sesh/pages?user=test&coll=default-collection', params=page)
 
         assert res.json == {}
 

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -168,11 +168,11 @@ class FullStackTests(BaseWRTests):
 
     @classmethod
     def _anon_post(self, url, *args, **kwargs):
-        return self.testapp.post(self._format_url(url), *args, **kwargs)
+        return self.testapp.post_json(self._format_url(url), *args, **kwargs)
 
     @classmethod
     def _anon_delete(self, url, *args, **kwargs):
-        return self.testapp.delete(self._format_url(url), *args, **kwargs)
+        return self.testapp.delete_json(self._format_url(url), *args, **kwargs)
 
     @classmethod
     def _anon_get(self, url, *args, **kwargs):

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -93,8 +93,8 @@ class BaseController(object):
         result = {'error_message': message}
         result.update(kwargs)
 
-        if request.forms:
-            result['request_data'] = dict(request.forms.decode())
+        if request.json:
+            result['request_data'] = dict(request.json)
 
         err = HTTPError(code, message, exception=result)
         if api:

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -20,14 +20,14 @@ class CollsController(BaseController):
         def create_collection():
             user = self.get_user(api=True, redir_check=False)
 
-            title = request.forms.getunicode('title')
+            title = request.json.get('title')
 
             coll_name = self.sanitize_title(title)
 
             if not coll_name:
                 return {'error_message': 'Invalid Collection Name'}
 
-            is_public = self.post_get('public') == 'on'
+            is_public = request.json.get('public')
 
             if self.access.is_anon(user):
                 if coll_name != 'temp':

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -1,4 +1,4 @@
-from bottle import request
+from bottle import request, response
 from six.moves.urllib.parse import quote
 
 from webrecorder.basecontroller import BaseController
@@ -106,6 +106,14 @@ class CollsController(BaseController):
                 #if self.access.is_superuser() and data.get('notify'):
                 #    pass
                 self.access.set_public(collection, data['public'])
+
+            if 'featured_list' in data:
+                blist = collection.get_list(data['featured_list'])
+                if not blist:
+                    response.status = 400
+                    return {'error': 'no_such_list'}
+
+                collection['featured_list'] = data['featured_list']
 
             return {'collection': collection.serialize()}
 

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -105,7 +105,10 @@ class CollsController(BaseController):
             if 'public' in data:
                 #if self.access.is_superuser() and data.get('notify'):
                 #    pass
-                self.access.set_public(collection, data['public'])
+                collection.set_public(data['public'])
+
+            if 'public_index' in data:
+                collection.set_bool_prop('public_index', data['public_index'])
 
             if 'featured_list' in data:
                 blist = collection.get_list(data['featured_list'])

--- a/webrecorder/webrecorder/listscontroller.py
+++ b/webrecorder/webrecorder/listscontroller.py
@@ -1,6 +1,8 @@
 from webrecorder.basecontroller import BaseController
 from bottle import request
 
+from webrecorder.utils import get_bool
+
 
 # ============================================================================
 class ListsController(BaseController):
@@ -10,14 +12,12 @@ class ListsController(BaseController):
         def get_lists():
             user, collection = self.load_user_coll()
 
-            with_bookmarks = True
-            if request.query.include_bookmarks:
-                with_bookmarks = request.query.include_bookmarks == 'true'
+            include_bookmarks = request.query.include_bookmarks or 'all'
 
             lists = collection.get_lists()
 
             return {
-                'lists': [blist.serialize(include_bookmarks=with_bookmarks)
+                'lists': [blist.serialize(include_bookmarks=include_bookmarks)
                           for blist in lists]
             }
 

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -178,7 +178,7 @@ class MainController(BaseController):
         def get_coll(context):
             return context.get('coll', '')
 
-        def get_user_coll(context):
+        def get_collection(context):
             coll = context.get('coll', '')
             coll_name = context.get('coll_name', '')
             user = get_user(context)
@@ -208,11 +208,11 @@ class MainController(BaseController):
 
         @contextfunction
         def is_public(context):
-            return self.access.is_public(get_user_coll(context))
+            return get_collection(context).is_public()
 
         @contextfunction
         def can_admin(context):
-            return self.access.can_admin_coll(get_user_coll(context))
+            return self.access.can_admin_coll(get_collection(context))
 
         @contextfunction
         def is_owner(context):
@@ -221,12 +221,12 @@ class MainController(BaseController):
 
         @contextfunction
         def can_write(context):
-            res = self.access.can_write_coll(get_user_coll(context))
+            res = self.access.can_write_coll(get_collection(context))
             return res
 
         @contextfunction
         def can_read(context):
-            res = self.access.can_read_coll(get_user_coll(context))
+            res = self.access.can_read_coll(get_collection(context))
 
         @contextfunction
         def is_anon(context):
@@ -290,7 +290,7 @@ class MainController(BaseController):
 
         @contextfunction
         def get_recs_for_coll(context):
-            collection = get_user_coll(context)
+            collection = get_collection(context)
 
             return [{'ts': r['timestamp'], 'url': r['url'], 'br': r.get('browser', '')}
                     for r in collection.list_coll_pages()]

--- a/webrecorder/webrecorder/models/base.py
+++ b/webrecorder/webrecorder/models/base.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from webrecorder.utils import get_bool
 
 
 # ============================================================================
@@ -43,6 +44,18 @@ class RedisUniqueComponent(object):
     def incr_size(self, size):
         val = self.redis.hincrby(self.info_key, 'size', size)
         self.data['size'] = int(val)
+
+    def set_bool_prop(self, prop, value):
+        self.set_prop(prop, self._from_bool(value))
+
+    def get_bool_prop(self, prop, default_val=False):
+        return get_bool(self.get_prop(prop, default_val=False))
+
+    def is_public(self):
+        return self.get_bool_prop('public')
+
+    def set_public(self, value):
+        self.set_bool_prop('public', value)
 
     def load(self):
         self.data = self.redis.hgetall(self.info_key)
@@ -154,6 +167,10 @@ class RedisUniqueComponent(object):
         if no_T:
             dt = dt.replace('T', ' ')
         return dt
+
+    @classmethod
+    def _from_bool(self, value):
+        return '1' if value else '0'
 
 
 # ============================================================================

--- a/webrecorder/webrecorder/models/base.py
+++ b/webrecorder/webrecorder/models/base.py
@@ -94,7 +94,7 @@ class RedisUniqueComponent(object):
                 if force_type:
                     self.data[attr] = force_type(self.data[attr])
 
-        return self.data.get(attr)
+        return self.data.get(attr, default_val)
 
     def set_prop(self, attr, value):
         self.data[attr] = value
@@ -249,8 +249,8 @@ class RedisOrderedListMixin(object):
     def _ordered_list_key(self):
         return self.ORDERED_LIST_KEY.format_map({self.MY_TYPE: self.my_id})
 
-    def get_ordered_objects(self, cls, load=True):
-        all_objs = self.redis.zrange(self._ordered_list_key, 0, -1)
+    def get_ordered_objects(self, cls, load=True, start=0, end=-1):
+        all_objs = self.redis.zrange(self._ordered_list_key, start, end)
 
         obj_list = []
         for val in all_objs:

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -213,7 +213,17 @@ class Collection(RedisOrderedListMixin, RedisNamedContainer):
 
         if include_recordings:
             recordings = self.get_recordings(load=True)
-            data['recordings'] = [recording.serialize() for recording in recordings]
+            rec_serialized = []
+
+            duration = 0
+            for recording in recordings:
+                rec_data = recording.serialize()
+                rec_serialized.append(rec_data)
+                duration += rec_data.get('duration', 0)
+
+            data['recordings'] = rec_serialized
+
+            data['duration'] = duration
 
         if include_lists:
             lists = self.get_lists(load=True, public_only=True)

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -6,8 +6,6 @@ import hashlib
 from pywb.utils.loaders import load
 from warcio.timeutils import timestamp20_now
 
-from webrecorder.utils import redis_pipeline
-
 from webrecorder.models.base import RedisNamedContainer, RedisOrderedListMixin
 from webrecorder.models.recording import Recording
 from webrecorder.models.list_bookmarks import BookmarkList
@@ -29,8 +27,6 @@ class Collection(RedisOrderedListMixin, RedisNamedContainer):
     COLL_CDXJ_TTL = 1800
 
     INDEX_FILE_KEY = '@index_file'
-
-    PUBLIC_FLAG = 'r:@public'
 
     @classmethod
     def init_props(cls, config):
@@ -125,11 +121,9 @@ class Collection(RedisOrderedListMixin, RedisNamedContainer):
         self.data = {'title': title,
                      'size': 0,
                      'desc': desc,
+                     'public': self._from_bool(public),
+                     'public_index': True,
                     }
-
-        if public:
-            #TODO: standardize prop?
-            self.data[self.PUBLIC_FLAG] = '1'
 
         self._init_new()
 
@@ -225,6 +219,8 @@ class Collection(RedisOrderedListMixin, RedisNamedContainer):
             lists = self.get_lists(load=True, public_only=True)
             data['lists'] = [blist.serialize(include_bookmarks='first') for blist in lists]
 
+        data['public'] = self.is_public()
+        data['public_index'] = self.get_bool_prop('public_index', True)
         return data
 
     def rename(self, obj, new_name, new_cont=None, allow_dupe=False):

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -67,13 +67,14 @@ class Collection(RedisOrderedListMixin, RedisNamedContainer):
 
         return bookmark_list
 
-    def get_lists(self, load=True):
+    def get_lists(self, load=True, public_only=False):
         self.access.assert_can_read_coll(self)
 
         lists = self.get_ordered_objects(BookmarkList, load=load)
 
-        if not self.access.can_write_coll(self):
-            lists = [blist for blist in lists if self.access.can_read_list(blist)]
+        if public_only or not self.access.can_write_coll(self):
+            lists = [blist for blist in lists if blist.is_public()]
+            #lists = [blist for blist in lists if self.access.can_read_list(blist)]
 
         return lists
 
@@ -221,8 +222,8 @@ class Collection(RedisOrderedListMixin, RedisNamedContainer):
             data['recordings'] = [recording.serialize() for recording in recordings]
 
         if include_lists:
-            lists = self.get_lists(load=True)
-            data['lists'] = [blist.serialize(include_bookmarks=False) for blist in lists]
+            lists = self.get_lists(load=True, public_only=True)
+            data['lists'] = [blist.serialize(include_bookmarks='first') for blist in lists]
 
         return data
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -92,7 +92,7 @@ class BookmarkList(RedisOrderedListMixin, RedisUniqueComponent):
         else:
             data['num_bookmarks'] = self.num_bookmarks()
 
-        data['public'] = get_bool(data['public'])
+        data['public'] = get_bool(data.get('public', False))
 
         return data
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -108,9 +108,6 @@ class BookmarkList(RedisOrderedListMixin, RedisUniqueComponent):
 
         return data
 
-    def is_public(self):
-        return get_bool(self.get_prop('public', default_val=False))
-
     def update(self, props):
         self.access.assert_can_write_coll(self.get_owner())
 
@@ -121,12 +118,9 @@ class BookmarkList(RedisOrderedListMixin, RedisUniqueComponent):
             if prop in props:
                 value = props[prop]
                 if prop == 'public':
-                    value = self._from_bool(value)
-                self.set_prop(prop, value)
-
-    @classmethod
-    def _from_bool(self, value):
-        return '1' if value else '0'
+                    self.set_public(value)
+                else:
+                    self.set_prop(prop, value)
 
     def delete_me(self):
         self.access.assert_can_write_coll(self.get_owner())

--- a/webrecorder/webrecorder/recscontroller.py
+++ b/webrecorder/webrecorder/recscontroller.py
@@ -12,10 +12,12 @@ class RecsController(BaseController):
         def create_recording():
             user, collection = self.load_user_coll()
 
-            rec_title = request.forms.getunicode('title', '')
+            data = request.json or {}
+
+            rec_title = data.get('title', '')
             rec_title = self.sanitize_title(rec_title)
 
-            desc = request.forms.getunicode('desc', '')
+            desc = data.get('desc', '')
 
             recording = collection.create_recording(rec_title, desc=desc)
 
@@ -44,7 +46,7 @@ class RecsController(BaseController):
 
             user.access.assert_can_write_coll(collection)
 
-            desc = request.forms.getunicode('desc', '')
+            desc = request.json.get('desc', '')
 
             recording['desc'] = desc
 
@@ -86,7 +88,7 @@ class RecsController(BaseController):
         def add_page(rec_name):
             user, collection, recording = self.load_recording(rec_name)
 
-            page_data = dict(request.forms.decode())
+            page_data = request.json
 
             res = recording.add_page(page_data)
             return res
@@ -95,7 +97,7 @@ class RecsController(BaseController):
         def modify_page(rec_name):
             user, collection, recording = self.load_recording(rec_name)
 
-            page_data = dict(request.forms.decode())
+            page_data = request.json
 
             res = recording.modify_page(page_data)
             return {'page-data': page_data, 'recording-id': rec_name}
@@ -117,8 +119,8 @@ class RecsController(BaseController):
         def delete_page(rec_name):
             user, collection, recording = self.load_recording(rec_name)
 
-            url = request.forms.getunicode('url')
-            ts = request.forms.getunicode('timestamp')
+            url = request.json.get('url')
+            ts = request.json.get('timestamp')
 
             return recording.delete_page(url, ts)
 

--- a/webrecorder/webrecorder/templates/collection_info.html
+++ b/webrecorder/webrecorder/templates/collection_info.html
@@ -43,7 +43,7 @@
                 {% set is_disabled_class = "disabled" %}
             {% endif %}
             <div class="access-switch" style="float:right;">
-                {% set is_public = collection['r:@public'] %}
+                {% set is_public = collection['public'] %}
                 {% include 'public_private_switch.html' %}
             </div>
         {% endif %}

--- a/webrecorder/webrecorder/templates/user.html
+++ b/webrecorder/webrecorder/templates/user.html
@@ -54,7 +54,7 @@
 <div class="row">
     <ul class="list-group collection-list">
         {% for coll in collections | sort(attribute='title') %}
-        {% set is_public = coll['r:@public'] %}
+        {% set is_public = coll['public'] %}
         <li class="left-buffer list-group-item">
             <div class="row">
                 <div class="col-xs-9">

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -61,11 +61,11 @@ def sanitize_title(title):
 
 
 # ============================================================================
-def get_bool(string):
-    if not string:
-        return False
+def get_bool(value):
+    if isinstance(value, str):
+        return value.lower() not in ('0', 'false', 'f', 'off')
 
-    return string.lower() not in ('0', 'false', 'f', 'off')
+    return False if not value else True
 
 
 # ============================================================================


### PR DESCRIPTION
Breaking API changes:
- Switch all API to accept json instead of form-encoding
- Default error page is a json response
- Collection and List include 'public' boolean to indicate if public
- Collection supports 'featured_list' and 'public_index'
- Collection api includes public lists and first bookmark
- Collection and recording include 'timespan' and 'duration'