### PR TITLE
uuid fixes: 

### DIFF
--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -7,6 +7,8 @@ from webrecorder.models.list_bookmarks import BookmarkList, Bookmark
 
 # ============================================================================
 class TestListsAnonUserAPI(FullStackTests):
+    ID_1 = 'e5371563ab'
+
     @classmethod
     def setup_class(cls):
         super(TestListsAnonUserAPI, cls).setup_class()
@@ -36,7 +38,8 @@ class TestListsAnonUserAPI(FullStackTests):
                       timestamp='20181226000800',
                       browser='chrome:60',
                       desc='A description for this bookmark',
-                      page_id=None):
+                      page_id=None,
+                      rec='rec'):
 
         params = {'title': title,
                   'url': url,
@@ -47,6 +50,7 @@ class TestListsAnonUserAPI(FullStackTests):
 
         if page_id:
             params['id'] = page_id
+            params['rec'] = rec
 
         res = self.testapp.post_json(self._format('/api/v1/list/%s/bookmarks?user={user}&coll=temp' % list_id), params=params)
         return res
@@ -258,14 +262,14 @@ class TestListsAnonUserAPI(FullStackTests):
     # ========================================================================
     def test_create_page(self):
         page_id = self._add_page('rec', title='A Page', url='http://example.com/испытание/test')
-        assert page_id == 'b874ad9c6d'
+        assert page_id == self.ID_1
 
 
     # Bookmarks
     # ========================================================================
     def test_create_bookmark(self):
         res = self._add_bookmark('1002', title='An Example (испытание)', url='http://example.com/испытание/test',
-                                 page_id='b874ad9c6d')
+                                 page_id=self.ID_1)
 
         bookmark = res.json['bookmark']
 
@@ -281,13 +285,13 @@ class TestListsAnonUserAPI(FullStackTests):
         assert bookmark['browser'] == 'chrome:60'
         assert bookmark['desc'] == 'A description for this bookmark'
 
-        assert bookmark['page']['id'] == 'b874ad9c6d'
+        assert bookmark['page']['id'] == self.ID_1
         assert bookmark['page']['url'] == bookmark['url']
         assert bookmark['page']['timestamp'] == bookmark['timestamp']
 
     def test_create_bookmark_error_page_not_matcching(self):
         res = self._add_bookmark('1002', title='An Example (испытание)', url='http://example.com/испытание/test',
-                                 timestamp='2018', page_id='b874ad9c6d')
+                                 timestamp='2018', page_id=self.ID_1)
 
         # urls and timestamps of page and bookmark must match
         assert res.json['error'] == 'invalid_page'
@@ -403,11 +407,11 @@ class TestListsAnonUserAPI(FullStackTests):
 
     def test_multiple_bookmarks_for_page(self):
         res = self._add_bookmark('1003', title='An Example 2', url='http://example.com/испытание/test',
-                                 page_id='b874ad9c6d')
+                                 page_id=self.ID_1)
 
         res = self.testapp.get(self._format('/api/v1/collection/temp/page_bookmarks?user={user}'))
 
-        assert res.json == {'page_bookmarks': {'b874ad9c6d': {'111': '1003', '101': '1002'}}}
+        assert res.json == {'page_bookmarks': {self.ID_1: {'111': '1003', '101': '1002'}}}
 
     def test_coll_info_with_lists(self):
         res = self.testapp.get(self._format('/api/v1/collection/temp?user={user}'))

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -49,6 +49,7 @@ class TestListsAPIAccess(FullStackTests):
 
         assert res.json['list']
         list_id = res.json['list']['id']
+        assert len(list_id) == 8
         assert res.json['list']['public'] == public
 
         # Bookmark
@@ -58,7 +59,7 @@ class TestListsAPIAccess(FullStackTests):
                  }
 
         res = self.testapp.post_json('/api/v1/list/%s/bookmarks?user={0}&coll=some-coll'.format(user) % list_id, params=params)
-        assert res.json['bookmark']
+        assert len(res.json['bookmark']['id']) == 8
 
         # Another  Bookmark
         params = {'title': 'Another Bookmark',

--- a/webrecorder/test/test_recs_api.py
+++ b/webrecorder/test/test_recs_api.py
@@ -8,6 +8,10 @@ from itertools import count
 
 # ============================================================================
 class TestWebRecRecAPI(FullStackTests):
+    ID_1 = '55e75e6bfd'
+    ID_2 = '9e77ef03aa'
+    ID_3 = 'b87a6b2374'
+
     @classmethod
     def setup_class(cls):
         super(TestWebRecRecAPI, cls).setup_class()
@@ -110,12 +114,12 @@ class TestWebRecRecAPI(FullStackTests):
         page = {'title': 'Example', 'url': 'http://example.com/', 'timestamp': '2016010203000000'}
         res = self._anon_post('/api/v1/recording/{rec_id_0}/pages?user={user}&coll=temp', params=page)
 
-        assert res.json['page_id'] == 'cf6e50ec2c'
+        assert res.json['page_id'] == self.ID_1
 
     def test_page_list_1(self):
         res = self._anon_get('/api/v1/recording/{rec_id_0}/pages?user={user}&coll=temp')
 
-        assert res.json == {'pages': [{'id': 'cf6e50ec2c',
+        assert res.json == {'pages': [{'id': self.ID_1,
                                        'rec': 'rec-a',
                                        'title': 'Example',
                                        'url': 'http://example.com/',
@@ -128,7 +132,7 @@ class TestWebRecRecAPI(FullStackTests):
         page = {'title': 'Example', 'url': 'http://example.com/foo/bar', 'timestamp': '2015010203000000'}
         res = self._anon_post('/api/v1/recording/{rec_id_0}/pages?user={user}&coll=temp', params=page)
 
-        assert res.json['page_id'] == 'ce9820d103'
+        assert res.json['page_id'] == self.ID_2
 
     def test_page_add_3_not_added_yet(self):
         #cdx_key = 'r:{user}:temp:{rec_id}:cdxj'.format(user=self.anon_user, rec_id=self.rec_ids[0])
@@ -136,20 +140,20 @@ class TestWebRecRecAPI(FullStackTests):
         page = {'title': 'Example', 'url': 'http://example.com/foo/other'}
         res = self._anon_post('/api/v1/recording/{rec_id_0}/pages?user={user}&coll=temp', params=page)
 
-        assert res.json['page_id'] == 'c196be3dde'
+        assert res.json['page_id'] == self.ID_3
 
     def test_page_list_2(self):
         res = self._anon_get('/api/v1/recording/{rec_id_0}/pages?user={user}&coll=temp')
         assert len(res.json['pages']) == 3
-        assert {'id': 'cf6e50ec2c', 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/', 'timestamp': '2016010203000000'} in res.json['pages']
-        assert {'id': 'ce9820d103', 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/foo/bar', 'timestamp': '2015010203000000'} in res.json['pages']
+        assert {'id': self.ID_1, 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/', 'timestamp': '2016010203000000'} in res.json['pages']
+        assert {'id': self.ID_2, 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/foo/bar', 'timestamp': '2015010203000000'} in res.json['pages']
 
     def test_coll_page_list(self):
         res = self._anon_get('/api/v1/collection/temp?user={user}')
 
         assert len(res.json['collection']['pages']) == 3
-        assert {'id': 'cf6e50ec2c', 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/', 'timestamp': '2016010203000000'} in res.json['collection']['pages']
-        assert {'id': 'ce9820d103', 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/foo/bar', 'timestamp': '2015010203000000'} in res.json['collection']['pages']
+        assert {'id': self.ID_1, 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/', 'timestamp': '2016010203000000'} in res.json['collection']['pages']
+        assert {'id': self.ID_2, 'rec': 'rec-a', 'title': 'Example', 'url': 'http://example.com/foo/bar', 'timestamp': '2015010203000000'} in res.json['collection']['pages']
 
     def _test_page_delete(self):
         params = {'url': 'http://example.com/foo/bar', 'timestamp': '2015010203000000'}

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -13,6 +13,10 @@ from warcio import ArchiveIterator
 
 # ============================================================================
 class TestUpload(FullStackTests):
+    ID_1 = '1884e17293'
+    ID_2 = 'eed99fa580'
+    ID_3 = '9871d09bf7'
+
     @classmethod
     def setup_class(cls, **kwargs):
         super(TestUpload, cls).setup_class(temp_worker=True)
@@ -196,7 +200,7 @@ class TestUpload(FullStackTests):
         assert collection['id'] == 'temporary-collection'
         assert collection['title'] == 'Temporary Collection'
 
-        assert collection['pages'] == [{'id': '07dbfa5824',
+        assert collection['pages'] == [{'id': self.ID_1,
                                         'rec': 'uploaded-rec',
                                         'timestamp': '20180306181354',
                                         'title': 'Example Domain',
@@ -238,13 +242,15 @@ class TestUpload(FullStackTests):
 
         assert len(collection['pages']) == 2
 
-        assert {'id': '07dbfa5824',
+        print(collection['pages'])
+
+        assert {'id': self.ID_2,
                 'rec': 'upload-rec-2',
                 'timestamp': '20180306181354',
                 'title': 'Example Domain',
                 'url': 'http://example.com/'} in collection['pages']
 
-        assert {'id': '7aeff3ce47',
+        assert {'id': self.ID_3,
                 'rec': 'rec-sesh',
                 'timestamp': '',
                 'title': 'Example Title',

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -168,12 +168,12 @@ class FullStackTests(HttpBinLiveTests, BaseWRTests):
                        'BookmarkList': []
                       }
 
-        def get_new_id_o(self):
+        def get_new_id_o(self, max_len=None):
             try:
                 id_gen = cls.ids_map.get(self.__class__.__name__)
                 return str(next(id_gen))
             except:
-                return get_new_id()
+                return get_new_id(max_len)
 
         return get_new_id_o
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -10,6 +10,8 @@ class BookmarkList(RedisUniqueComponent):
 
     BOOKMARKS_KEY = 'l:{blist}:bookmarks'
 
+    ID_LEN = 8
+
     def __init__(self, **kwargs):
         super(BookmarkList, self).__init__(**kwargs)
         self.bookmarks = RedisOrderedList(self.BOOKMARKS_KEY, self)
@@ -145,6 +147,8 @@ class Bookmark(RedisUniqueComponent):
     MY_TYPE = 'book'
     INFO_KEY = 'b:{book}:info'
     ALL_KEYS = 'b:{book}:*'
+
+    ID_LEN = 8
 
     def init_new(self, bookmark_list, collection, props):
         self.owner = bookmark_list

--- a/webrecorder/webrecorder/models/pages.py
+++ b/webrecorder/webrecorder/models/pages.py
@@ -34,7 +34,7 @@ class PagesMixin(object):
         return pid
 
     def _new_page_id(self, page):
-        page_attrs = (page['url'] + page['timestamp']).encode('utf-8')
+        page_attrs = (page['url'] + page['timestamp'] + page.get('rec', '') + page.get('browser', '')).encode('utf-8')
         return hashlib.md5(page_attrs).hexdigest()[:10]
 
     def is_matching_page(self, pid, page):
@@ -95,8 +95,8 @@ class PagesMixin(object):
             if 'ts' in page and 'timestamp' not in page:
                 page['timestamp'] = page.pop('ts')
 
-            pid = self._new_page_id(page)
             page['rec'] = recording.my_id
+            pid = self._new_page_id(page)
 
             pages[pid] = json.dumps(page)
 

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -54,8 +54,11 @@ def init_props(config):
 
 
 # ============================================================================
-def get_new_id():
-    return base64.b32encode(os.urandom(10)).decode('utf-8').lower()
+def get_new_id(max_len=None):
+    res = base64.b32encode(os.urandom(10)).decode('utf-8').lower()
+    if max_len:
+        res = res[:max_len]
+    return res
 
 
 # ============================================================================


### PR DESCRIPTION
- for lists and bookmarks, use shorter, 8-char uuid
- test for dupes when allocating new uuid
- for pages, use rec id + browser in hash key to allow dupe pages and different browsers