### PR TITLE
API Work 2

### DIFF
--- a/frontend/src/components/siteComponents/UploadUI/index.js
+++ b/frontend/src/components/siteComponents/UploadUI/index.js
@@ -156,7 +156,7 @@ class UploadUI extends Component {
 
     this.setState({
       canCancel: true,
-      status: data.error_message || 'Error Encountered'
+      status: data.error || 'Error Encountered'
     });
   }
 

--- a/frontend/src/containers/RegisterAccount/RegisterAccount.js
+++ b/frontend/src/containers/RegisterAccount/RegisterAccount.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import config from 'config';
 
 
 class RegisterAccount extends Component {
@@ -21,13 +22,14 @@ class RegisterAccount extends Component {
   componentDidMount() {
     const { match } = this.props;
     const reg = match.params.registration;
-    document.cookie = `valreg=${reg}; Max-Age=60; Path=/api/v1/userval`;
+    const validateApi = `${config.apiPath}/auth/validate`;
+    document.cookie = `valreg=${reg}; Max-Age=60; Path=${validateApi}`;
 
     const data = new FormData();
     data.append('reg', reg);
 
     // call user registration endpoint
-    fetch('/api/v1/userval', {
+    fetch(validateApi, {
       credentials: 'same-origin',
       method: 'POST',
       body: data

--- a/frontend/src/helpers/ApiClient.js
+++ b/frontend/src/helpers/ApiClient.js
@@ -54,7 +54,7 @@ export default class ApiClient {
         request.end((err, res) => {
           const { body } = res;
 
-          return err || !body || body.hasOwnProperty('error_message') ?
+          return err || !body || body.hasOwnProperty('error') ?
             reject(body || err) :
             resolve(body);
         });

--- a/frontend/src/redux/modules/auth.js
+++ b/frontend/src/redux/modules/auth.js
@@ -84,14 +84,14 @@ export function isLoaded({ app }) {
 export function load() {
   return {
     types: [LOAD, LOAD_SUCCESS, LOAD_FAIL],
-    promise: client => client.get(`${config.apiPath}/load_auth`)
+    promise: client => client.get(`${config.apiPath}/auth`)
   };
 }
 
 export function login(postData) {
   return {
     types: [LOGIN, LOGIN_SUCCESS, LOGIN_FAIL],
-    promise: client => client.post(`${config.apiPath}/login`, {
+    promise: client => client.post(`${config.apiPath}/auth/login`, {
       data: {
         ...postData
       }
@@ -109,6 +109,6 @@ export function incrementCollCount(incr) {
 export function logout() {
   return {
     types: [LOGOUT, LOGOUT_SUCCESS, LOGOUT_FAIL],
-    promise: client => client.get(`${config.apiPath}/logout`)
+    promise: client => client.get(`${config.apiPath}/auth/logout`)
   };
 }

--- a/frontend/src/redux/modules/collection.js
+++ b/frontend/src/redux/modules/collection.js
@@ -128,7 +128,7 @@ export default function collection(state = initialState, action = {}) {
       });
     case COLL_EDIT_FAIL:
       return state.merge({
-        editError: action.error.error_message
+        editError: action.error.error
       });
     case RESET_EDIT_STATE:
       return state.set('edited', false);

--- a/frontend/src/redux/modules/collections.js
+++ b/frontend/src/redux/modules/collections.js
@@ -48,7 +48,7 @@ export default function collections(state = initialState, action = {}) {
         accessed: null
       });
     case CREATE_COLL_FAIL:
-      return state.set('error', action.error.error_message);
+      return state.set('error', action.error.error);
 
     default:
       return state;

--- a/frontend/src/redux/modules/list.js
+++ b/frontend/src/redux/modules/list.js
@@ -136,23 +136,35 @@ export function edit(user, coll, id, data) {
 }
 
 
-export function addTo(user, coll, listId, data) {
+export function addTo(user, coll, listId, page) {
+  // if page id is specified, replace with 'page_id'
+  if (page.id) {
+    page.page_id = page.id;
+    page.id = undefined;
+  }
   return {
     types: [LIST_ADD, LIST_ADD_SUCCESS, LIST_ADD_FAIL],
     promise: client => client.post(`${apiPath}/list/${listId}/bookmarks`, {
       params: { user, coll },
-      data
+      data: page
     })
   };
 }
 
 
-export function bulkAddTo(user, coll, listId, data) {
+export function bulkAddTo(user, coll, listId, pages) {
+  pages.forEach((page) => {
+    if (page.id) {
+      page.page_id = page.id;
+      page.id = undefined;
+    }
+  });
+
   return {
     types: [BULK_ADD, BULK_ADD_SUCCESS, BULK_ADD_FAIL],
     promise: client => client.post(`${apiPath}/list/${listId}/bulk_bookmarks`, {
       params: { user, coll },
-      data
+      data: pages
     })
   };
 }

--- a/frontend/src/redux/modules/passwordReset.js
+++ b/frontend/src/redux/modules/passwordReset.js
@@ -1,3 +1,5 @@
+import config from 'config';
+
 const RESET = 'wr/passwordReset/RESET';
 const RESET_SUCCESS = 'wr/passwordReset/RESET_SUCCESS';
 const RESET_FAIL = 'wr/passwordReset/RESET_FAIL';
@@ -33,7 +35,7 @@ export default function passwordReset(state = initialState, action = {}) {
 export function resetPassword(postData) {
   return {
     types: [RESET, RESET_SUCCESS, RESET_FAIL],
-    promise: client => client.post('/_forgot', {
+    promise: client => client.post(`${config.apiPath}/auth/password/reset_request`, {
       data: {
         ...postData
       }

--- a/frontend/src/redux/modules/tempUser.js
+++ b/frontend/src/redux/modules/tempUser.js
@@ -24,7 +24,7 @@ export default function tempUser(state = initialState, action = {}) {
       return state.merge({
         user: {
           accessed: action.accessed,
-          ...action.result,
+          ...action.result.user,
         }
       });
     case TEMP_LOAD_FAIL:
@@ -38,6 +38,6 @@ export function load(username) {
   return {
     types: [TEMP_LOAD, TEMP_LOAD_SUCCESS, TEMP_LOAD_FAIL],
     accessed: Date.now(),
-    promise: client => client.get(`${apiPath}/temp-users/${username}`)
+    promise: client => client.get(`${apiPath}/user/${username}`)
   };
 }

--- a/frontend/src/redux/modules/user.js
+++ b/frontend/src/redux/modules/user.js
@@ -82,7 +82,7 @@ export default function user(state = initialState, action = {}) {
         passUpdateFail: null
       });
     case USER_PASS_FAIL:
-      return state.set('passUpdateFail', action.error.error_message);
+      return state.set('passUpdateFail', action.error.error);
     default:
       return state;
   }

--- a/frontend/src/redux/modules/user.js
+++ b/frontend/src/redux/modules/user.js
@@ -155,7 +155,7 @@ export function deleteUserCollection(id) {
 export function updatePassword(currPass, newPass, newPass2) {
   return {
     types: [USER_PASS, USER_PASS_SUCCESS, USER_PASS_FAIL],
-    promise: client => client.post(`${config.apiPath}/auth/updatepassword`, {
+    promise: client => client.post(`${config.apiPath}/auth/password/update`, {
       data: {
         currPass,
         newPass,

--- a/frontend/src/redux/modules/user.js
+++ b/frontend/src/redux/modules/user.js
@@ -99,7 +99,7 @@ export function getDeleteToken(user) {
 export function deleteUser(user) {
   return {
     types: [USER_DELETE, USER_DELETE_SUCCESS, USER_DELETE_FAIL],
-    promise: client => client.del(`${config.apiPath}/users/${user}`)
+    promise: client => client.del(`${config.apiPath}/user/${user}`)
   };
 }
 
@@ -112,7 +112,7 @@ export function load(username) {
   return {
     types: [USER_LOAD, USER_LOAD_SUCCESS, USER_LOAD_FAIL],
     accessed: Date.now(),
-    promise: client => client.get(`${config.apiPath}/users/${username}`, {
+    promise: client => client.get(`${config.apiPath}/user/${username}`, {
       params: { include_colls: true }
     })
   };
@@ -155,12 +155,12 @@ export function deleteUserCollection(id) {
 export function updatePassword(currPass, newPass, newPass2) {
   return {
     types: [USER_PASS, USER_PASS_SUCCESS, USER_PASS_FAIL],
-    promise: client => client.post(`${config.apiPath}/updatepassword`, {
+    promise: client => client.post(`${config.apiPath}/auth/updatepassword`, {
       data: {
         currPass,
         newPass,
         newPass2
       }
-    }, 'form')
+    })
   };
 }

--- a/frontend/src/redux/modules/userSignup.js
+++ b/frontend/src/redux/modules/userSignup.js
@@ -59,16 +59,14 @@ export function checkUser(username) {
   return {
     types: [USERNAME_CHECK, USERNAME_CHECK_SUCCESS, USERNAME_CHECK_ERROR],
     username,
-    promise: client => client.get(`${config.apiPath}/username_check?`, {
-      params: { username }
-    })
+    promise: client => client.get(`${config.apiPath}/auth/check_username/${username}`)
   };
 }
 
 export function sendSignup(postData) {
   return {
     types: [SIGNUP, SIGNUP_SUCCESS, SIGNUP_FAIL],
-    promise: client => client.post(`${config.apiPath}/userreg`, {
+    promise: client => client.post(`${config.apiPath}/auth/register`, {
       data: {
         ...postData
       }

--- a/webrecorder/test/test_admin_api.py
+++ b/webrecorder/test/test_admin_api.py
@@ -9,13 +9,14 @@ class TestAdminAPI(FullStackTests):
         cls.user_manager = CLIUserManager()
 
     def test_no_auth_admin_users(self):
-        res = self.testapp.get('/api/v1/users')
-        # no permissions, redirect to _login
-        assert res.headers['Location'].endswith('_login')
+        res = self.testapp.get('/api/v1/users', status=404)
+        # no permissions, just display 404
+        assert res.json == {'error': 'not_found'}
 
     def test_no_auth_admin_dashboard(self):
-        res = self.testapp.get('/api/v1/dashboard')
-        assert res.headers['Location'].endswith('_login')
+        res = self.testapp.get('/api/v1/dashboard', status=404)
+        # no permissions, just display 404
+        assert res.json == {'error': 'not_found'}
 
     def test_no_auth_client_archives(self):
         res = self.testapp.get('/api/v1/client_archives/')

--- a/webrecorder/test/test_anon_workflow.py
+++ b/webrecorder/test/test_anon_workflow.py
@@ -612,7 +612,7 @@ class TestTempContent(FullStackTests):
 
         res = self.testapp.delete('/api/v1/recording/my-recording?user={user}&coll=temp'.format(user=self.anon_user), status=404)
 
-        assert res.json == {'id': 'my-recording', 'error_message': 'Recording not found'}
+        assert res.json == {'error': 'recording_not_found'}
 
     def test_anon_record_redirect_and_delete(self):
         self.set_uuids('Recording', ['recording-session'])

--- a/webrecorder/test/test_api_user_login.py
+++ b/webrecorder/test/test_api_user_login.py
@@ -33,7 +33,7 @@ class TestApiUserLogin(FullStackTests):
 
         res = self.testapp.post_json('/api/v1/userreg', params=params, status=400)
 
-        assert res.json == {'errors': {'validation': 'Passwords do not match!'}}
+        assert res.json == {'errors': {'validation': 'password_mismatch'}}
 
 
     def test_api_register_fail_bad_password(self):
@@ -46,7 +46,7 @@ class TestApiUserLogin(FullStackTests):
 
         res = self.testapp.post_json('/api/v1/userreg', params=params, status=400)
 
-        assert res.json == {'errors': {'validation': 'Please choose a different password'}}
+        assert res.json == {'errors': {'validation': 'password_invalid'}}
 
     def test_api_register_fail_bad_user(self):
         # bad user
@@ -124,7 +124,7 @@ class TestApiUserLogin(FullStackTests):
 
     def test_api_logout(self):
         res = self.testapp.get('/api/v1/logout', status=200)
-        assert res.json['message']
+        assert res.json['success']
 
         assert self.testapp.cookies.get('__test_sesh', '') == ''
 
@@ -225,7 +225,7 @@ class TestApiUserLogin(FullStackTests):
         # TODO: should be working with post_json?
         res = self.testapp.post('/api/v1/updatepassword', params=params, status=403)
 
-        assert res.json['error_message'] == 'Passwords do not match!'
+        assert res.json['error'] == 'password_mismatch'
 
     def test_update_password(self):
         params = {'currPass': 'Password1',
@@ -286,9 +286,9 @@ class TestApiUserLogin(FullStackTests):
         assert 'collections' not in user
 
     def test_delete_no_such_user(self):
-        res = self.testapp.delete('/api/v1/users/someuser2')
+        res = self.testapp.delete('/api/v1/users/someuser2', status=404)
 
-        assert res.json == {'error_message': 'Could not delete user: someuser2'}
+        assert res.json == {'error': 'no_such_user'}
 
     def test_delete_user(self):
         res = self.testapp.delete('/api/v1/users/someuser')

--- a/webrecorder/test/test_auto_login.py
+++ b/webrecorder/test/test_auto_login.py
@@ -49,7 +49,7 @@ class TestAutoLogin(FullStackTests):
         assert res.json['page_id'] == self.ID_1
 
     def test_api_curr_user(self):
-        res = self.testapp.get('/api/v1/curr_user')
+        res = self.testapp.get('/api/v1/auth/curr_user')
         assert res.json == {'curr_user': 'test'}
 
     def test_get_collection(self):

--- a/webrecorder/test/test_cdxj_cache.py
+++ b/webrecorder/test/test_cdxj_cache.py
@@ -168,7 +168,7 @@ class TestCDXJCache(FullStackTests):
         self.sleep_try(0.1, 10.0, assert_deleted)
 
     def test_user_timespan(self):
-        res = self.testapp.get('/api/v1/users/' + self.anon_user)
+        res = self.testapp.get('/api/v1/user/' + self.anon_user)
         # modified after delete, should have taken more than 2 seconds to get here
         assert res.json['user']['timespan'] > 2
 

--- a/webrecorder/test/test_colls_api.py
+++ b/webrecorder/test/test_colls_api.py
@@ -19,11 +19,11 @@ class TestWebRecCollsAPI(FullStackTests):
 
     def test_create_anon_coll_dup_error(self):
         res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user),
-                                     params={'title': 'Temp'})
+                                     params={'title': 'Temp'}, status=400)
 
         assert self.testapp.cookies['__test_sesh'] != ''
 
-        assert 'error_message' in res.json
+        assert res.json == {'error': 'duplicate_name'}
 
     def test_get_anon_coll(self):
         res = self.testapp.get('/api/v1/collection/temp?user={user}'.format(user=self.anon_user))
@@ -57,20 +57,19 @@ class TestWebRecCollsAPI(FullStackTests):
 
     def test_error_no_such_coll(self):
         res = self.testapp.get('/api/v1/collection/blah@$?user={user}'.format(user=self.anon_user), status=404)
-        #assert res.json == {'error_message': 'Collection not found', 'id': 'blah@$'}
-        assert res.json == {'error_message': 'No such collection'}
+        assert res.json == {'error': 'no_such_collection'}
 
     def test_error_missing_user_coll(self):
         res = self.testapp.post_json('/api/v1/collections', params={'title': 'Recording'}, status=400)
-        assert res.json == {'error_message': "User must be specified", 'request_data': {'title': 'Recording'}}
+        assert res.json == {'error': 'no_user_specified'}
 
     def test_error_invalid_user_coll(self):
         res = self.testapp.post_json('/api/v1/collections?user=user', params={'title': 'Example'}, status=404)
-        assert res.json == {"error_message": "No such user", 'request_data': {'title': 'Example'}}
+        assert res.json == {'error': 'no_such_user'}
 
     def test_error_invalid_user_coll_2(self):
         res = self.testapp.post_json('/api/v1/collections?user=temp$123', params={'title': 'Example'}, status=404)
-        assert res.json == {"error_message": "No such user", 'request_data': {'title': 'Example'}}
+        assert res.json == {'error': 'no_such_user'}
 
     def test_delete_coll(self):
         res = self.testapp.delete('/api/v1/collection/temp?user={user}'.format(user=self.anon_user))

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -456,7 +456,7 @@ class TestListsAnonUserAPI(FullStackTests):
             assert 'recordings' in coll
 
     def test_user_info(self):
-        res = self.testapp.get(self._format('/api/v1/users/{user}?include_colls=true'))
+        res = self.testapp.get(self._format('/api/v1/user/{user}?include_colls=true'))
 
         user = res.json['user']
 

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -23,14 +23,14 @@ class TestListsAnonUserAPI(FullStackTests):
 
             return new_bookmark_id_actual
 
-        cls.id_mock = patch('webrecorder.models.list_bookmarks.BookmarkList.get_new_bookmark_id',
+        cls.bid_mock = patch('webrecorder.models.list_bookmarks.BookmarkList.get_new_bookmark_id',
                             new_bookmark_id(count(101)))
 
-        cls.id_mock.start()
+        cls.bid_mock.start()
 
     @classmethod
     def teardown_class(cls):
-        cls.id_mock.stop()
+        cls.bid_mock.stop()
 
         super(TestListsAnonUserAPI, cls).teardown_class()
 

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -77,7 +77,7 @@ class TestListsAPIAccess(FullStackTests):
                   'password': 'TestTest123',
                  }
 
-        res = self.testapp.post_json('/api/v1/login', params=params)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
         assert res.json['username'] == 'test'
         assert self.testapp.cookies['__test_sesh'] != ''
 
@@ -103,13 +103,13 @@ class TestListsAPIAccess(FullStackTests):
         assert res.json['collection']['recordings'] == []
 
     def test_logout_login_user_2(self):
-        res = self.testapp.get('/api/v1/logout', status=200)
+        res = self.testapp.get('/api/v1/auth/logout', status=200)
 
         params = {'username': 'another',
                   'password': 'TestTest456',
                  }
 
-        res = self.testapp.post_json('/api/v1/login', params=params)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
         assert res.json['username'] == 'another'
         assert self.testapp.cookies['__test_sesh'] != ''
 
@@ -150,9 +150,9 @@ class TestListsAPIAccess(FullStackTests):
 
     def test_no_lists_user_info(self):
         # wrong user
-        res = self.testapp.get('/api/v1/users/test', status=404)
+        res = self.testapp.get('/api/v1/user/test', status=404)
 
-        res = self.testapp.get('/api/v1/users/another')
+        res = self.testapp.get('/api/v1/user/another')
 
         assert len(res.json['user']['collections']) == 2
         for coll in res.json['user']['collections']:
@@ -171,7 +171,7 @@ class TestListsAPIAccess(FullStackTests):
         res = self.testapp.get('/api/v1/lists?user=test&coll=some-coll', status=404)
 
     def test_public_list_private_coll_error_logged_out(self):
-        res = self.testapp.get('/api/v1/logout')
+        res = self.testapp.get('/api/v1/auth/logout')
 
         res = self.testapp.get('/api/v1/lists?user=test&coll=some-coll', status=404)
 
@@ -202,7 +202,7 @@ class TestListsAPIAccess(FullStackTests):
                   'password': 'TestTest123',
                  }
 
-        res = self.testapp.post_json('/api/v1/login', params=params)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
         assert res.json['username'] == 'test'
         assert self.testapp.cookies['__test_sesh'] != ''
 

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -145,8 +145,12 @@ class TestListsAPIAccess(FullStackTests):
         assert set(self.redis.hkeys('u:test:colls')) == {'some-coll', 'default-collection'}
         assert set(self.redis.hkeys('u:another:colls')) == {'some-coll', 'default-collection'}
 
-        assert len(self.redis.keys('l:*:info')) == 4
-        assert len(self.redis.keys('b:*:info')) == 8
+        lists = self.redis.keys('l:*:info')
+        assert len(lists) == 4
+
+        for blist in lists:
+            assert self.redis.hlen(blist.replace(':info', ':b')) == 2
+        #assert len(self.redis.keys('b:*:info')) == 8
 
     def test_no_lists_user_info(self):
         # wrong user

--- a/webrecorder/test/test_recs_api.py
+++ b/webrecorder/test/test_recs_api.py
@@ -166,23 +166,23 @@ class TestWebRecRecAPI(FullStackTests):
 
     def test_error_no_such_rec(self):
         res = self._anon_get('/api/v1/recording/blah@$?user={user}&coll=temp', status=404)
-        assert res.json == {'error_message': 'Recording not found', 'id': 'blah@$'}
+        assert res.json == {'error': 'recording_not_found'}
 
     def test_error_no_such_rec_pages(self):
         res = self._anon_get('/api/v1/recording/my-rec3/pages?user={user}&coll=temp', status=404)
-        assert res.json == {'error_message': 'Recording not found', 'id': 'my-rec3'}
+        assert res.json == {'error': 'recording_not_found'}
 
         page = {'title': 'Example', 'url': 'http://example.com/foo/bar', 'timestamp': '2015010203000000'}
         res = self._anon_post('/api/v1/recording/my-rec3/pages?user={user}&coll=temp', params=page, status=404)
-        assert res.json == {'error_message': 'Recording not found', 'id': 'my-rec3', 'request_data': page}
+        assert res.json == {'error': 'recording_not_found'}
 
     def test_error_missing_user_coll(self):
         res = self._anon_post('/api/v1/recordings', params={'title': 'Recording'}, status=400)
-        assert res.json == {'error_message': "User must be specified", 'request_data': {'title': 'Recording'}}
+        assert res.json == {'error': 'no_user_specified'}
 
     def test_error_invalid_user_coll(self):
         res = self._anon_post('/api/v1/recordings?user=user&coll=coll', params={'title': 'Recording'}, status=404)
-        assert res.json == {"error_message": "No such user", 'request_data': {'title': 'Recording'}}
+        assert res.json == {'error': 'no_such_user'}
 
     def test_update_desc(self):
         test_desc = 'Test / Special Chars !'

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -230,9 +230,9 @@ class TestRegisterMigrate(FullStackTests):
 
         params = {'title': 'New Coll'}
 
-        res = self.testapp.post_json('/api/v1/collection/other-coll?user=someuser', params=params)
+        res = self.testapp.post_json('/api/v1/collection/other-coll?user=someuser', params=params, status=400)
 
-        assert res.json == {'error_message': 'duplicate name: new-coll'}
+        assert res.json == {'error': 'duplicate_name'}
 
         params = {'title': 'New Coll 3'}
 

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -71,7 +71,7 @@ class TestRegisterMigrate(FullStackTests):
 
         with patch('cork.Mailer.send_email', self.mock_send_reg_email):
             #res = self.testapp.post('/_register', params=params)
-            res = self.testapp.post_json('/api/v1/userreg', params=params)
+            res = self.testapp.post_json('/api/v1/auth/register', params=params)
 
         #assert res.headers['Location'] == 'http://localhost:80/'
         assert res.json == {
@@ -415,21 +415,21 @@ class TestRegisterMigrate(FullStackTests):
 
     def test_error_logged_out_record(self):
         res = self.testapp.get('/someuser/new-coll/move-test/record/mp_/http://example.com/', status=404)
-        assert res.json == {'error': 'not_found'}
+        assert res.json == {'error': 'no_such_recording'}
 
     def test_error_logged_out_patch(self):
         res = self.testapp.get('/someuser/new-coll/move-test/patch/mp_/http://example.com/', status=404)
-        assert res.json == {'error': 'not_found'}
+        assert res.json == {'error': 'no_such_recording'}
 
     def test_error_logged_out_replay_coll_1(self):
         res = self.testapp.get('/someuser/test-migrate/mp_/http://httpbin.org/get?food=bar', status=404)
-        assert res.json == {'error': 'not_found'}
+        assert res.json == {'error': 'no_such_collection'}
 
     def test_login(self):
         params = {'username': 'someuser',
                   'password': 'Password1'}
 
-        res = self.testapp.post_json('/api/v1/login', params=params)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
         assert res.json == {'anon': False,
                             'coll_count': 4,
                             'role': 'archivist',
@@ -549,7 +549,7 @@ class TestRegisterMigrate(FullStackTests):
         params = {'username': 'testauto',
                   'password': 'Test12345'}
 
-        res = self.testapp.post_json('/api/v1/login', params=params)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
 
         assert res.json == {'anon': False,
                             'coll_count': 1,
@@ -582,7 +582,7 @@ class TestRegisterMigrate(FullStackTests):
 
     def test_different_user_replay_private_error(self):
         res = self.testapp.get('/someuser/test-migrate/mp_/http://httpbin.org/get?food=bar', status=404)
-        assert res.json == {'error': 'not_found'}
+        assert res.json == {'error': 'no_such_collection'}
 
     def test_logout_3(self):
         res = self.testapp.get('/_logout')
@@ -593,7 +593,7 @@ class TestRegisterMigrate(FullStackTests):
         params = {'username': 'someuser',
                   'password': 'Password1'}
 
-        res = self.testapp.post_json('/api/v1/login', params=params)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
 
         assert res.json == {'anon': False,
                             'coll_count': 3,
@@ -650,7 +650,7 @@ class TestRegisterMigrate(FullStackTests):
         params = {'username': 'someuser',
                   'password': 'Password1'}
 
-        res = self.testapp.post_json('/api/v1/login', params=params, status=401)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params, status=401)
         assert res.json == {"error": "Invalid Login. Please Try Again"}
 
         assert self.testapp.cookies.get('__test_sesh', '') == ''

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -41,7 +41,7 @@ class TestUpload(FullStackTests):
                   'password': 'TestTest123',
                  }
 
-        res = self.testapp.post_json('/api/v1/login', params=params)
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
 
         assert res.json == {'anon': False,
                             'coll_count': 1,

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -29,9 +29,9 @@ class TestUpload(FullStackTests):
 
     def test_upload_anon(self):
         with open(self.test_upload_warc, 'rb') as fh:
-            res = self.testapp.put('/_upload?filename=example2.warc.gz', params=fh.read())
+            res = self.testapp.put('/_upload?filename=example2.warc.gz', params=fh.read(), status=400)
 
-        assert res.json == {'error_message': 'Sorry, uploads only available for logged-in users'}
+        assert res.json == {'error': 'not_logged_in'}
 
     def test_create_user_def_coll(self):
         self.manager.create_user('test@example.com', 'test', 'TestTest123', 'archivist', 'Test')
@@ -276,9 +276,9 @@ class TestUpload(FullStackTests):
 
     def test_upload_anon_2(self):
         with open(self.test_upload_warc, 'rb') as fh:
-            res = self.testapp.put('/_upload?filename=example2.warc.gz', params=fh.read())
+            res = self.testapp.put('/_upload?filename=example2.warc.gz', params=fh.read(), status=400)
 
-        assert res.json == {'error_message': 'Sorry, uploads only available for logged-in users'}
+        assert res.json == {'error': 'not_logged_in'}
 
     def test_stats(self):
         assert self.redis.hget(Stats.DOWNLOADS_KEY, today_str()) == '1'

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -96,7 +96,7 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
         cls.testapp = webtest.TestApp(cls.maincont.app)
 
         if init_anon:
-            res = cls.testapp.get('/api/v1/anon_user')
+            res = cls.testapp.get('/api/v1/auth/anon_user')
             cls.anon_user = res.json['anon_user']
         else:
             cls.anon_user = None

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -164,7 +164,6 @@ class FullStackTests(HttpBinLiveTests, BaseWRTests):
     def new_id_override(cls):
         cls.ids_map = {'Recording': [],
                        'Collection': [],
-                       'Bookmark': [],
                        'BookmarkList': []
                       }
 
@@ -185,7 +184,6 @@ class FullStackTests(HttpBinLiveTests, BaseWRTests):
         res = self.testapp.get(url, *args, **kwargs)
         assert res.status_code == 302
         rec_id = res.location.split('/', 7)[5]
-        print(rec_id)
         self.add_rec_id(rec_id)
         return res
 

--- a/webrecorder/webrecorder/admincontroller.py
+++ b/webrecorder/webrecorder/admincontroller.py
@@ -37,7 +37,7 @@ class AdminController(BaseController):
         return check_access
 
     def init_routes(self):
-        @self.app.get('/api/v1/defaults')
+        @self.app.get('/api/v1/admin/defaults')
         @self.admin_view
         def get_defaults():
             data = self.redis.hgetall('h:defaults')
@@ -45,7 +45,7 @@ class AdminController(BaseController):
             data['max_anon_size'] = int(data['max_anon_size'])
             return {'defaults': data}
 
-        @self.app.put('/api/v1/defaults')
+        @self.app.put('/api/v1/admin/defaults')
         def update_defaults():
             data = request.json
             if 'max_size' in data:
@@ -65,12 +65,12 @@ class AdminController(BaseController):
             data['max_anon_size'] = int(data['max_anon_size'])
             return {'defaults': data}
 
-        @self.app.get(['/api/v1/user_roles', '/api/v1/user_roles/'])
+        @self.app.get('/api/v1/admin/user_roles')
         @self.admin_view
         def api_get_user_roles():
             return {"roles": self.user_manager.get_roles()}
 
-        @self.app.get(['/api/v1/dashboard', '/api/v1/dashboard/'])
+        @self.app.get('/api/v1/admin/dashboard')
         @self.admin_view
         def api_dashboard():
             cache_key = self.cache_template.format('dashboard')
@@ -107,7 +107,7 @@ class AdminController(BaseController):
 
             return data
 
-        @self.app.get(['/api/v1/users', '/api/v1/users/'])
+        @self.app.get('/api/v1/admin/users')
         @self.admin_view
         def api_users():
             """Full admin API resource of all users.
@@ -142,7 +142,7 @@ class AdminController(BaseController):
 
             return {'users': [self.user_manager.all_users[user].serialize(compute_size_allotment=True) for user in users]}
 
-        @self.app.get('/api/v1/temp-users')
+        @self.app.get('/api/v1/admin/temp-users')
         @self.admin_view
         def temp_users():
             """ Resource returning active temp users
@@ -162,7 +162,7 @@ class AdminController(BaseController):
 
             return {'users': temp_user_data}
 
-        @self.app.post(['/api/v1/users', '/api/v1/users/'])
+        @self.app.post('/api/v1/admin/users')
         @self.admin_view
         def api_create_user():
             """API enpoint to create a user"""
@@ -183,7 +183,7 @@ class AdminController(BaseController):
             user, first_coll = res
             return {'user': user.name, 'first_coll': first_coll.name if first_coll else ''}
 
-        @self.app.put(['/api/v1/users/<username>', '/api/v1/users/<username>/'])
+        @self.app.put('/api/v1/admin/user/<username>')
         @self.admin_view
         def api_update_user(username):
             """API enpoint to update user info (full access)

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -172,8 +172,8 @@ class ContentController(BaseController, RewriterApp):
 
             data = self.browser_mgr.request_new_browser(kwargs)
 
-            if 'error_message' in data:
-                self._raise_error(400, data['error_message'])
+            if 'error' in data:
+                self._raise_error(400, data['error'])
 
             return data
 
@@ -235,7 +235,7 @@ class ContentController(BaseController, RewriterApp):
             domain = request.forms.getunicode('domain')
 
             if not domain:
-                return {'error_message': 'no domain'}
+                return self._raise_error(400, 'domain_missing')
 
             self.add_cookie(user, collection, recording, name, value, domain)
 
@@ -408,7 +408,7 @@ class ContentController(BaseController, RewriterApp):
     def do_proxy(self, url):
         info = self.browser_mgr.init_cont_browser_sesh()
         if not info:
-            return {'error_message': 'conn not from valid containerized browser'}
+            return self._raise_error(400, 'invalid_connection_source')
 
         try:
             kwargs = info

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -430,7 +430,7 @@ class ContentController(BaseController, RewriterApp):
 
             if remote_ip and info['type'] in self.MODIFY_MODES:
                 if user.is_rate_limited(remote_ip):
-                    raise HTTPError(402, 'Rate Limit')
+                    self._raise_error(402, 'rate_limit_exceeded')
 
             resp = self.render_content(wb_url, kwargs, request.environ)
 
@@ -584,21 +584,21 @@ class ContentController(BaseController, RewriterApp):
                                          wb_url)
 
                 # don't auto create recording for inner frame w/o accessing outer frame
-                raise HTTPError(404, 'No Such Recording')
+                self._raise_error(404, 'no_such_recording')
 
             elif not recording.is_open():
                 # force creation of new recording as this one is closed
-                raise HTTPError(404, 'Recording not open')
+                self._raise_error(400, 'recording_not_open')
 
             collection.access.assert_can_write_coll(collection)
 
             if the_user.is_out_of_space():
-                raise HTTPError(402, 'Out of Space')
+                self._raise_error(402, 'out_of_space')
 
             remote_ip = self._get_remote_ip()
 
             if the_user.is_rate_limited(remote_ip):
-                raise HTTPError(402, 'Rate Limit')
+                self._raise_error(402, 'rate_limit_exceeded')
 
             if inv_sources and inv_sources != '*':
                 #patch_rec_name = self.patch_of_name(rec, True)
@@ -612,18 +612,18 @@ class ContentController(BaseController, RewriterApp):
                                          wb_url)
 
 
-                raise HTTPError(404, 'No Such Collection')
+                self._raise_error(404, 'no_such_collection')
 
             access = self.access.check_read_access_public(collection)
             if not access:
-                raise HTTPError(404, 'No Such Collection')
+                self._raise_error(404, 'no_such_collection')
 
             if access != 'public':
                 frontend_cache_header = ('Cache-Control', 'private')
 
         elif type == 'replay':
             if not recording:
-                raise HTTPError(404, 'No Such Recording')
+                self._raise_error(404, 'no_such_recording')
 
         request.environ['SCRIPT_NAME'] = quote(request.environ['SCRIPT_NAME'], safe='/:')
 

--- a/webrecorder/webrecorder/listscontroller.py
+++ b/webrecorder/webrecorder/listscontroller.py
@@ -52,7 +52,7 @@ class ListsController(BaseController):
             if collection.remove_list(blist):
                 return {'deleted_id': list_id}
             else:
-                return {'error': 'error deleting: ' + list_id}
+                self._raise_error(400, 'error_deleting')
 
         @self.app.post('/api/v1/list/<list_id>/move')
         def move_list_before(list_id):
@@ -66,7 +66,7 @@ class ListsController(BaseController):
                 before = None
 
             collection.move_list_before(blist, before)
-            return {'success': 'list moved'}
+            return {'success': 'list_moved'}
 
         @self.app.post('/api/v1/lists/reorder')
         def reorder_lists():
@@ -77,7 +77,7 @@ class ListsController(BaseController):
             if collection.lists.reorder_objects(new_order):
                 return {'success': 'reordered'}
             else:
-                return {'error': 'invalid_order'}
+                return self._raise_error(400, 'invalid_order')
 
 
         #BOOKMARKS
@@ -89,7 +89,7 @@ class ListsController(BaseController):
             if bookmark:
                 return {'bookmark': bookmark.serialize()}
             else:
-                return {'error': 'invalid_page'}
+                return self._raise_error(400, 'invalid_page')
 
         @self.app.post('/api/v1/list/<list_id>/bulk_bookmarks')
         def create_bookmarks(list_id):
@@ -130,7 +130,7 @@ class ListsController(BaseController):
             if blist.remove_bookmark(bookmark):
                 return {'deleted_id': bid}
             else:
-                return {'error': 'error deleting: ' + bid}
+                self._raise_error(400, 'error_deleting')
 
         @self.app.post('/api/v1/list/<list_id>/bookmarks/reorder')
         def reorder_bookmarks(list_id):
@@ -141,7 +141,7 @@ class ListsController(BaseController):
             if blist.bookmarks.reorder_objects(new_order):
                 return {'success': 'reordered'}
             else:
-                return {'error': 'invalid_order'}
+                self._raise_error(400, 'invalid_order')
 
     def load_user_coll_list(self, list_id, user=None, coll_name=None):
         user, collection = self.load_user_coll(user=user, coll_name=coll_name)
@@ -151,8 +151,7 @@ class ListsController(BaseController):
     def load_list(self, collection, list_id):
         blist = collection.get_list(list_id)
         if not blist:
-            self._raise_error(404, 'List not found', api=True,
-                              id=list_id)
+            self._raise_error(404, 'no_such_list')
 
         return blist
 
@@ -161,14 +160,13 @@ class ListsController(BaseController):
             list_id = request.query.getunicode('list')
 
         if not list_id:
-            self._raise_error(400, 'list_id= must be specified', api=True)
+            self._raise_error(400, 'no_list_specified')
 
         user, collection, blist = self.load_user_coll_list(list_id, user=user, coll_name=coll_name)
 
         bookmark = blist.get_bookmark(bid)
         if not bookmark:
-            self._raise_error(404, 'Bookmark not found in list', api=True,
-                              id=bid)
+            self._raise_error(404, 'no_such_bookmark')
 
         return blist, bookmark
 

--- a/webrecorder/webrecorder/models/__init__.py
+++ b/webrecorder/webrecorder/models/__init__.py
@@ -2,6 +2,6 @@
 from .user import User, SessionUser
 from .collection import Collection
 from .recording import Recording
-from .list_bookmarks import BookmarkList, Bookmark
+from .list_bookmarks import BookmarkList
 from .stats import Stats
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -64,7 +64,10 @@ class BookmarkList(RedisUniqueComponent):
 
         order = self.bookmark_order.get_ordered_keys(start, end)
 
-        bookmarks = self.redis.hmget(self.BOOK_CONTENT_KEY.format(blist=self.my_id), order)
+        if order:
+            bookmarks = self.redis.hmget(self.BOOK_CONTENT_KEY.format(blist=self.my_id), order)
+        else:
+            bookmarks = []
 
         return [json.loads(bookmark) for bookmark in bookmarks]
 

--- a/webrecorder/webrecorder/models/pages.py
+++ b/webrecorder/webrecorder/models/pages.py
@@ -102,13 +102,13 @@ class PagesMixin(object):
 
         self.redis.hmset(self.pages_key, pages)
 
-    def add_page_bookmark(self, pid, bookmark):
+    def add_page_bookmark(self, pid, bid, list_id):
         key = self.PAGE_BOOKMARKS_KEY.format(coll=self.my_id, page=pid)
-        self.redis.hset(key, bookmark.my_id, bookmark.get_prop('owner'))
+        self.redis.hset(key, bid, list_id)
 
-    def remove_page_bookmark(self, pid, bookmark):
+    def remove_page_bookmark(self, pid, bid):
         key = self.PAGE_BOOKMARKS_KEY.format(coll=self.my_id, page=pid)
-        self.redis.hdel(key, bookmark.my_id)
+        self.redis.hdel(key, bid)
 
     def get_page_bookmarks(self):
         bookmarks = {}

--- a/webrecorder/webrecorder/models/usermanager.py
+++ b/webrecorder/webrecorder/models/usermanager.py
@@ -65,15 +65,6 @@ class UserManager(object):
         except Exception as e:
             print('WARNING: Unable to init defaults: ' + str(e))
 
-        # custom cork auth decorators
-        self.admin_view = self.cork.make_auth_decorator(role='admin',
-                                                        fixed_role=True,
-                                                        fail_redirect='/_login')
-        self.auth_view = self.cork.make_auth_decorator(role='archivist',
-                                                       fail_redirect='/_login')
-        self.beta_user = self.cork.make_auth_decorator(role='beta-archivist',
-                                                       fail_redirect='/_login')
-
         self.all_users = UserTable(self.redis, self._get_access)
 
         self.invites = RedisTable(self.redis, 'h:invites')
@@ -287,10 +278,10 @@ class UserManager(object):
 
     def validate_password(self, password, confirm):
         if password != confirm:
-            raise ValidationException('Passwords do not match!')
+            raise ValidationException('password_mismatch')
 
         if not self.PASS_RX.match(password):
-            raise ValidationException('Please choose a different password')
+            raise ValidationException('password_invalid')
 
         return True
 

--- a/webrecorder/webrecorder/models/usermanager.py
+++ b/webrecorder/webrecorder/models/usermanager.py
@@ -16,7 +16,7 @@ from string import ascii_lowercase as alpha
 from bottle import template, request
 #from cork import AAAException
 
-from webrecorder.webreccork import ValidationException
+from webrecorder.webreccork import ValidationException, AuthException
 
 from webrecorder.models.base import BaseAccess, DupeNameException
 from webrecorder.models.user import User, UserTable
@@ -318,12 +318,21 @@ class UserManager(object):
 
     def update_password(self, curr_password, password, confirm):
         username = self.access.session_user.name
+
         if not self.cork.verify_password(username, curr_password):
             raise ValidationException('Incorrect Current Password')
 
         self.validate_password(password, confirm)
 
         self.cork.update_password(username, password)
+
+    def reset_password(self, password, confirm, resetcode):
+        self.validate_password(password, confirm)
+
+        try:
+            self.cork.reset_password(resetcode, password)
+        except AuthException:
+            raise ValidationException('invalid_reset_code')
 
     def is_valid_invite(self, invitekey):
         try:

--- a/webrecorder/webrecorder/recscontroller.py
+++ b/webrecorder/webrecorder/recscontroller.py
@@ -36,7 +36,7 @@ class RecsController(BaseController):
             if recording:
                 return {'recording': recording.serialize()}
             else:
-                return {'error_message': 'Recording not found', 'id': rec}
+                self._raise_error(404, 'recording_not_found')
 
         @self.app.post('/api/v1/recording/<rec>')
         def update_rec_desc(rec):
@@ -66,7 +66,7 @@ class RecsController(BaseController):
 
             new_collection = user.get_collection_by_name(new_coll_name)
             if not new_collection:
-                return {'error_message': 'No Collection: ' + new_coll_name}
+                self._raise_error(400, 'no_such_collection')
 
             user.access.assert_can_admin_coll(new_collection)
 
@@ -79,7 +79,7 @@ class RecsController(BaseController):
                 #self.flash_message(msg, 'success')
                 return {'coll_id': new_coll_name, 'rec_id': new_rec}
             else:
-                return {'error': 'error_move_recording'}
+                self._raise_error(400, 'error_move_recording')
 
         @self.app.post('/api/v1/recording/<rec>/copy/<new_coll_name>')
         def copy_recording(rec, new_coll_name):
@@ -87,7 +87,7 @@ class RecsController(BaseController):
 
             new_collection = user.get_collection_by_name(new_coll_name)
             if not new_collection:
-                return {'error_message': 'No Collection: ' + new_coll_name}
+                return self._raise_error(400, 'no_such_collection')
 
             user.access.assert_can_write_coll(collection)
             user.access.assert_can_admin_coll(new_collection)
@@ -97,7 +97,7 @@ class RecsController(BaseController):
             if new_rec.copy_data_from_recording(recording):
                 return {'recording': new_rec.serialize()}
             else:
-                return {'error': 'copy_error'}
+                return self._raise_error(400, 'copy_error')
 
         @self.app.post('/api/v1/recording/<rec>/pages')
         def add_page(rec):
@@ -180,12 +180,10 @@ class RecsController(BaseController):
     def load_recording(self, rec, user=None, coll_name=None):
         user, collection = self.load_user_coll(user=user, coll_name=coll_name)
         if not user or not collection:
-            self._raise_error(404, 'Recording not found', api=True,
-                              id=rec)
+            self._raise_error(404, 'recording_not_found')
 
         recording = collection.get_recording(rec)
         if not recording:
-            self._raise_error(404, 'Recording not found', api=True,
-                              id=rec)
+            self._raise_error(404, 'recording_not_found')
 
         return user, collection, recording

--- a/webrecorder/webrecorder/uploadcontroller.py
+++ b/webrecorder/webrecorder/uploadcontroller.py
@@ -19,12 +19,12 @@ class UploadController(BaseController):
         @self.app.put('/_upload')
         def upload_file():
             if self.access.session_user.is_anon():
-                return {'error_message': 'Sorry, uploads only available for logged-in users'}
+                return self._raise_error(400, 'not_logged_in')
 
             expected_size = int(request.headers['Content-Length'])
 
             if not expected_size:
-                return {'error_message': 'No File Specified'}
+                return self._raise_error(400, 'no_file_specified')
 
             force_coll_name = request.query.getunicode('force-coll', '')
             filename = request.query.getunicode('filename')
@@ -46,7 +46,7 @@ class UploadController(BaseController):
             props = self.uploader.get_upload_status(user, upload_id)
 
             if not props:
-                return {'error_message': 'upload expired'}
+                return self._raise_error(400, 'upload_expired')
 
             return props
 

--- a/webrecorder/webrecorder/websockcontroller.py
+++ b/webrecorder/webrecorder/websockcontroller.py
@@ -283,8 +283,7 @@ class BaseWebSockHandler(object):
                                     self.stats_urls)
 
         else:
-            result = {'ws_type': 'error',
-                      'error_message': 'not found'}
+            result = {'ws_type': 'error', 'error': 'not_found'}
 
         return json.dumps(result)
 


### PR DESCRIPTION
- Better reorganize apis, such as `/api/v1/auth/` for auth related apis, `/api/v1/admin/` for admin apis
- More consistent 4xx error messages
- Bookmarks: use a hashmap for all bookmarks instead of a key per bookmark
- Password apis: add password reset request and reset confirmation at `/api/v1/auth/password/reset_request` and `/api/v1/auth/password/reset`