### PR TITLE
bookmark deletion improvements:

### DIFF
--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -125,7 +125,9 @@ class CollsController(BaseController):
         def get_page_bookmarks(coll_name):
             user, collection = self.load_user_coll(coll_name=coll_name)
 
-            return {'page_bookmarks': collection.get_page_bookmarks()}
+            rec = request.query.get('rec')
+
+            return {'page_bookmarks': collection.get_page_bookmarks(rec)}
 
         # Create Collection
         @self.app.get('/_create')

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -183,8 +183,11 @@ class BookmarkList(RedisUniqueComponent):
         page_data_list = self.get_owner().get_pages_for_list(page_ids)
 
         for bookmark, page in zip(page_bookmarks, page_data_list):
-            bookmark['page'] = json.loads(page)
-            bookmark['page']['id'] = bookmark['page_id']
+            if page:
+                bookmark['page'] = json.loads(page)
+                bookmark['page']['id'] = bookmark['page_id']
+            else:
+                bookmark.pop('page_id', '')
 
         return bookmarks
 


### PR DESCRIPTION
- when deleting a session, delete associated bookmarks for each page in the session
- /page_bookmarks api supports rec=... to filter pages for a particular session (for display)
- bookmark serialization: if bookmark 'page_id' points to invalid page, don't attemtp to load/clear page_id