### PR TITLE
List Slug and Rename Redirect Support

### DIFF
--- a/frontend/src/components/HttpStatus/index.js
+++ b/frontend/src/components/HttpStatus/index.js
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import Helmet from 'react-helmet';
 import { Panel } from 'react-bootstrap';
 
 import SetStatus from 'components/SetStatus';
@@ -20,6 +21,9 @@ class HttpStatus extends PureComponent {
 
     return (
       <SetStatus code={status}>
+        <Helmet>
+          <title>There's been an error</title>
+        </Helmet>
         <Panel bsStyle="danger" className="wr-error-notice">
           <Panel.Heading>There's been an error</Panel.Heading>
           <Panel.Body>

--- a/frontend/src/components/RemoveWidget/index.js
+++ b/frontend/src/components/RemoveWidget/index.js
@@ -50,11 +50,11 @@ class RemoveWidget extends Component {
         return;
       }
 
-      this.props.callback();
       this.setState({ confirmRemove: false });
+      this.props.callback();
+    } else {
+      this.setState({ confirmRemove: true });
     }
-
-    this.setState({ confirmRemove: true });
   }
 
   outsideClickCheck = (evt) => {

--- a/frontend/src/components/collection/CollectionCoverUI/index.js
+++ b/frontend/src/components/collection/CollectionCoverUI/index.js
@@ -55,16 +55,16 @@ class CollectionCoverUI extends Component {
       );
     }
 
-    const user = collection.get('user');
+    const user = collection.get('owner');
     const collId = collection.get('id');
     const lists = collection.get('lists') ? collection.get('lists').filter(o => o.get('public') && o.get('bookmarks') && o.get('bookmarks').size) : [];
 
     return (
       <div className="coll-cover">
         <Helmet>
-          <title>{`${collection.get('title')} (Web archive collection by ${collection.get('user')})`}</title>
+          <title>{`${collection.get('title')} (Web archive collection by ${collection.get('owner')})`}</title>
         </Helmet>
-        <Capstone user={collection.get('user')} />
+        <Capstone user={collection.get('owner')} />
         <h1>{collection.get('title')}</h1>
         <div className="description">
           <WYSIWYG

--- a/frontend/src/components/collection/CollectionCoverUI/index.js
+++ b/frontend/src/components/collection/CollectionCoverUI/index.js
@@ -4,9 +4,11 @@ import Helmet from 'react-helmet';
 import { Link } from 'react-router-dom';
 
 import { defaultCollDesc } from 'config';
+import { getCollectionLink, getListLink } from 'helpers/utils';
 
 import Capstone from 'components/collection/Capstone';
 import HttpStatus from 'components/HttpStatus';
+import RedirectWithStatus from 'components/RedirectWithStatus';
 import Truncate from 'components/Truncate';
 import WYSIWYG from 'components/WYSIWYG';
 import { ListIcon } from 'components/icons';
@@ -22,6 +24,7 @@ class CollectionCoverUI extends Component {
   static propTypes = {
     collection: PropTypes.object,
     history: PropTypes.object,
+    match: PropTypes.object,
     orderdPages: PropTypes.object
   };
 
@@ -31,20 +34,24 @@ class CollectionCoverUI extends Component {
 
     if (!canAdmin && orderdPages.size) {
       const pg = orderdPages.get(0);
-      return `/${collection.get('user')}/${collection.get('id')}/${pg.get('timestamp')}/${pg.get('url')}`;
+      return `${getCollectionLink(collection)}/${pg.get('timestamp')}/${pg.get('url')}`;
     }
 
-    return `/${collection.get('user')}/${collection.get('id')}/pages`;
+    return getCollectionLink(collection, true);
   }
 
   render() {
-    const { collection } = this.props;
+    const { collection, match: { params: { coll } } } = this.props;
 
     if (collection.get('error')) {
       return (
         <HttpStatus>
           {collection.getIn(['error', 'error_message'])}
         </HttpStatus>
+      );
+    } else if (collection.get('loaded') && !collection.get('slug_matched') && coll !== collection.get('slug')) {
+      return (
+        <RedirectWithStatus to={getCollectionLink(collection)} status={301} />
       );
     }
 
@@ -72,7 +79,7 @@ class CollectionCoverUI extends Component {
                 {
                   lists.map((list) => {
                     const bk = list.getIn(['bookmarks', '0']);
-                    const loc = `/${user}/${collId}/list/${list.get('id')}-${bk.get('id')}/${bk.get('timestamp')}/${bk.get('url')}`;
+                    const loc = `${getListLink(collection, list)}/b${bk.get('id')}/${bk.get('timestamp')}/${bk.get('url')}`;
                     return (
                       <li key={list.get('id')}>
                         <Link to={loc}>

--- a/frontend/src/components/collection/CollectionDetailUI/columns.js
+++ b/frontend/src/components/collection/CollectionDetailUI/columns.js
@@ -4,10 +4,10 @@ import defaultHeaderRenderer from 'react-virtualized/dist/commonjs/Table/default
 import { DropTarget, DragSource } from 'react-dnd';
 
 import { draggableTypes, untitledEntry } from 'config';
+import { capitalize, getCollectionLink, getListLink, remoteBrowserMod } from 'helpers/utils';
 
 import RemoveWidget from 'components/RemoveWidget';
 import TimeFormat from 'components/TimeFormat';
-import { capitalize, remoteBrowserMod } from 'helpers/utils';
 
 
 export function BasicRenderer({ cellData }) {
@@ -36,10 +36,10 @@ export function BrowserRenderer({ cellData, columnData: { browsers } }) {
 }
 
 
-export function LinkRenderer({ cellData, rowData, columnData: { collection, listId } }) {
-  const linkTo = listId ?
-    `/${collection.get('user')}/${collection.get('id')}/list/${listId}-${rowData.get('id')}/${remoteBrowserMod(rowData.get('browser'), rowData.get('timestamp'))}/${rowData.get('url')}` :
-    `/${collection.get('user')}/${collection.get('id')}/${remoteBrowserMod(rowData.get('browser'), rowData.get('timestamp'))}/${rowData.get('url')}`;
+export function LinkRenderer({ cellData, rowData, columnData: { collection, list } }) {
+  const linkTo = list ?
+    `${getListLink(collection, list)}/b${rowData.get('id')}/${remoteBrowserMod(rowData.get('browser'), rowData.get('timestamp'))}/${rowData.get('url')}` :
+    `${getCollectionLink(collection)}/${remoteBrowserMod(rowData.get('browser'), rowData.get('timestamp'))}/${rowData.get('url')}`;
   return (
     <Link
       to={linkTo}

--- a/frontend/src/components/collection/CollectionDetailUI/index.js
+++ b/frontend/src/components/collection/CollectionDetailUI/index.js
@@ -470,7 +470,7 @@ class CollectionDetailUI extends Component {
         cellRenderer: LinkRenderer,
         columnData: {
           collection,
-          list: activeList ? list.get('slug') : null
+          list: activeList ? list : null
         },
         dataKey: 'url',
         flexGrow: 1,

--- a/frontend/src/components/collection/CollectionDetailUI/index.js
+++ b/frontend/src/components/collection/CollectionDetailUI/index.js
@@ -485,8 +485,8 @@ class CollectionDetailUI extends Component {
         <Helmet>
           {
             activeList ?
-              <title>{`${list.get('title')} (List by ${collection.get('user')})`}</title> :
-              <title>{`${collection.get('title')} (Web archive collection by ${collection.get('user')})`}</title>
+              <title>{`${list.get('title')} (List by ${collection.get('owner')})`}</title> :
+              <title>{`${collection.get('title')} (Web archive collection by ${collection.get('owner')})`}</title>
           }
         </Helmet>
         <CustomDragLayer

--- a/frontend/src/components/collection/CollectionFiltersUI/index.js
+++ b/frontend/src/components/collection/CollectionFiltersUI/index.js
@@ -63,7 +63,7 @@ class CollectionFiltersUI extends Component {
       pagesToAdd.push(pages.get(selectedPageIdx).toJS());
     }
 
-    this.props.addPagesToLists(collection.get('user'), collection.get('id'), pagesToAdd, lists);
+    this.props.addPagesToLists(collection.get('owner'), collection.get('id'), pagesToAdd, lists);
     this.closeAddToList();
   }
 

--- a/frontend/src/components/collection/CollectionHeaderUI/index.js
+++ b/frontend/src/components/collection/CollectionHeaderUI/index.js
@@ -61,7 +61,7 @@ class CollectionHeaderUI extends Component {
 
   setPublic = () => {
     const { collection } = this.props;
-    this.props.editCollection(collection.get('user'), collection.get('id'), { public: !collection.get('public') });
+    this.props.editCollection(collection.get('owner'), collection.get('id'), { public: !collection.get('public') });
   }
 
   expandHeader = () => {
@@ -79,12 +79,12 @@ class CollectionHeaderUI extends Component {
 
   editCollTitle = (title) => {
     const { collection } = this.props;
-    this.props.editCollection(collection.get('user'), collection.get('id'), { title });
+    this.props.editCollection(collection.get('owner'), collection.get('id'), { title });
   }
 
   editDesc = (desc) => {
     const { collection, editCollection } = this.props;
-    editCollection(collection.get('user'), collection.get('id'), { desc });
+    editCollection(collection.get('owner'), collection.get('id'), { desc });
   }
 
   newCapture = () => {
@@ -193,7 +193,7 @@ class CollectionHeaderUI extends Component {
               </div> :
               <div className="overview" key="collOverview">
                 <div className={classNames('heading-row', { 'is-public': !canAdmin })}>
-                  <Capstone user={collection.get('user')} />
+                  <Capstone user={collection.get('owner')} />
                   <div className="heading-container">
                     {
                       canAdmin && !isAnon &&

--- a/frontend/src/components/collection/CollectionHeaderUI/index.js
+++ b/frontend/src/components/collection/CollectionHeaderUI/index.js
@@ -5,7 +5,7 @@ import { Button, DropdownButton, MenuItem } from 'react-bootstrap';
 import { CSSTransitionGroup } from 'react-transition-group';
 
 import { defaultCollDesc } from 'config';
-import { doubleRAF, stopPropagation } from 'helpers/utils';
+import { doubleRAF, getCollectionLink, stopPropagation } from 'helpers/utils';
 
 import { DeleteCollection, Upload } from 'containers';
 
@@ -89,17 +89,17 @@ class CollectionHeaderUI extends Component {
 
   newCapture = () => {
     const { collection, history } = this.props;
-    history.push(`/${collection.get('user')}/${collection.get('id')}/$new`);
+    history.push(`${getCollectionLink(collection)}/$new`);
   }
 
   manageCollection = () => {
     const { collection, history } = this.props;
-    history.push(`/${collection.get('user')}/${collection.get('id')}/management`);
+    history.push(`${getCollectionLink(collection)}/management`);
   }
 
   downloadCollection = () => {
     const { collection } = this.props;
-    window.location = `/${collection.get('user')}/${collection.get('id')}/$download`;
+    window.location = `${getCollectionLink(collection)}/$download`;
   }
 
   howTo = () => {
@@ -109,7 +109,7 @@ class CollectionHeaderUI extends Component {
 
   togglePublicView = () => {
     const { collection, history } = this.props;
-    history.push(`/${collection.get('user')}/${collection.get('id')}`);
+    history.push(getCollectionLink(collection));
     // const { location: { pathname, search }} = this.props;
     // const asPublic = search && search.indexOf('asPublic') !== -1;
     // if (asPublic) {

--- a/frontend/src/components/collection/CollectionListUI/index.js
+++ b/frontend/src/components/collection/CollectionListUI/index.js
@@ -5,10 +5,12 @@ import { fromJS } from 'immutable';
 import { Link } from 'react-router-dom';
 import { Button, Col, ProgressBar, Row } from 'react-bootstrap';
 
-import HttpStatus from 'components/HttpStatus';
-import SizeFormat from 'components/SizeFormat';
+import { getCollectionLink } from 'helpers/utils';
 
 import { Upload } from 'containers';
+
+import HttpStatus from 'components/HttpStatus';
+import SizeFormat from 'components/SizeFormat';
 import { NewCollection } from 'components/siteComponents';
 
 import './style.scss';
@@ -133,7 +135,7 @@ class CollectionListUI extends Component {
                       <li className="left-buffer list-group-item" key={coll.get('id')}>
                         <Row>
                           <Col xs={9}>
-                            <Link to={`/${userParam}/${coll.get('id')}${canAdmin ? '/pages' : ''}`} className="collection-title">{coll.get('title')}</Link>
+                            <Link to={getCollectionLink(coll, canAdmin)} className="collection-title">{coll.get('title')}</Link>
                           </Col>
                           <Col xs={2}>
                             <SizeFormat bytes={coll.get('size')} />

--- a/frontend/src/components/collection/CollectionManagementUI/index.js
+++ b/frontend/src/components/collection/CollectionManagementUI/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import Helmet from 'react-helmet';
 import { Button } from 'react-bootstrap';
 
+import { getCollectionLink } from 'helpers/utils';
+
 import { DeleteCollection, SessionCollapsible, Upload } from 'containers';
 
 import HttpStatus from 'components/HttpStatus';
@@ -40,7 +42,7 @@ class CollectionManagementUI extends Component {
 
   downloadAction = (evt) => {
     const { collection } = this.props;
-    window.location = `/${collection.get('user')}/${collection.get('id')}/$download`;
+    window.location = `${getCollectionLink(collection)}/$download`;
   }
 
 

--- a/frontend/src/components/collection/DeleteCollectionUI/index.js
+++ b/frontend/src/components/collection/DeleteCollectionUI/index.js
@@ -33,7 +33,7 @@ class DeleteCollectionUI extends Component {
     const { confirmDelete } = this.state;
 
     if (collection.get('title').match(new RegExp(`^${confirmDelete}$`, 'i'))) {
-      this.props.deleteColl(collection.get('user'), collection.get('id'));
+      this.props.deleteColl(collection.get('owner'), collection.get('id'));
     }
   }
 

--- a/frontend/src/components/collection/DeleteCollectionUI/index.js
+++ b/frontend/src/components/collection/DeleteCollectionUI/index.js
@@ -2,6 +2,8 @@ import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { Button, ControlLabel, FormControl, FormGroup } from 'react-bootstrap';
 
+import { getCollectionLink } from 'helpers/utils';
+
 import Modal from 'components/Modal';
 
 
@@ -71,7 +73,7 @@ class DeleteCollectionUI extends Component {
               <Button onClick={this.deleteCollection} disabled={this.validateConfirmDelete() !== 'success'} bsStyle="danger">Confirm Delete</Button>
             </React.Fragment>
           }>
-          <p>Are you sure you want to delete the collection <b>{collection.get('title')}</b> {`/${collection.get('user')}/${collection.get('id')}/`}?</p>
+          <p>Are you sure you want to delete the collection <b>{collection.get('title')}</b> {getCollectionLink(collection)}?</p>
           <p>If you confirm, <b>all recordings will be permanently deleted</b>.</p>
           <p>Be sure to download the collection first if you would like to keep any data.</p>
           <FormGroup validationState={this.validateConfirmDelete()}>

--- a/frontend/src/components/collection/InspectorPanelUI/index.js
+++ b/frontend/src/components/collection/InspectorPanelUI/index.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { Link } from 'react-router-dom';
 
 import { defaultBookmarkDesc, untitledEntry } from 'config';
+import { getCollectionLink } from 'helpers/utils';
 
 import InlineEditor from 'components/InlineEditor';
 import RemoteBrowserDisplay from 'components/collection/RemoteBrowserDisplay';
@@ -92,7 +93,7 @@ class InspectorPanelUI extends PureComponent {
                       <li>
                         <h5>Page Url</h5>
                         <span className="value">
-                          <Link to={`/${collection.get('user')}/${collection.get('id')}/${pg.get('timestamp')}/${pg.get('url')}`}>{pg.get('url')}</Link>
+                          <Link to={`${getCollectionLink(collection)}/${pg.get('timestamp')}/${pg.get('url')}`}>{pg.get('url')}</Link>
                         </span>
                       </li>
                       <li>
@@ -106,7 +107,7 @@ class InspectorPanelUI extends PureComponent {
                         <li>
                           <h5>Session ID</h5>
                           <span className="value">
-                            <Link to={`/${collection.get('user')}/${collection.get('id')}/pages?query=session:${pg.get('rec')}`}>{pg.get('rec')}</Link>
+                            <Link to={`${getCollectionLink(collection, true)}?query=session:${pg.get('rec')}`}>{pg.get('rec')}</Link>
                           </span>
                         </li>
                       }

--- a/frontend/src/components/collection/InspectorPanelUI/index.js
+++ b/frontend/src/components/collection/InspectorPanelUI/index.js
@@ -36,7 +36,7 @@ class InspectorPanelUI extends PureComponent {
   saveEdit = (data) => {
     const { collection, list, selectedBk } = this.props;
     this.props.saveBookmarkEdit(
-      collection.get('user'),
+      collection.get('owner'),
       collection.get('id'),
       list.get('id'),
       selectedBk,

--- a/frontend/src/components/collection/ListHeaderUI/index.js
+++ b/frontend/src/components/collection/ListHeaderUI/index.js
@@ -31,12 +31,12 @@ class ListHeaderUI extends PureComponent {
 
   editListTitle = (title) => {
     const { collection, editList, list } = this.props;
-    editList(collection.get('user'), collection.get('id'), list.get('id'), { title });
+    editList(collection.get('owner'), collection.get('id'), list.get('id'), { title });
   }
 
   editDesc = (desc) => {
     const { collection, list, editList } = this.props;
-    editList(collection.get('user'), collection.get('id'), list.get('id'), { desc });
+    editList(collection.get('owner'), collection.get('id'), list.get('id'), { desc });
   }
 
   startReplay = () => {
@@ -50,7 +50,7 @@ class ListHeaderUI extends PureComponent {
 
   viewCollection = () => {
     const { collection, history } = this.props;
-    history.push(getCollectionLink(collection));
+    history.push(getCollectionLink(collection, this.context.canAdmin));
   }
 
   render() {
@@ -58,7 +58,7 @@ class ListHeaderUI extends PureComponent {
     const { collection, list } = this.props;
     const bkCount = list.get('bookmarks').size;
     const bookmarks = `${bkCount} Page${bkCount === 1 ? '' : 's'}`;
-    const user = collection.get('user');
+    const user = collection.get('owner');
 
     return (
       <div className="wr-list-header">

--- a/frontend/src/components/collection/ListHeaderUI/index.js
+++ b/frontend/src/components/collection/ListHeaderUI/index.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { Alert, Button } from 'react-bootstrap';
 
 import { defaultListDesc } from 'config';
+import { getCollectionLink, getListLink } from 'helpers/utils';
 
 import InlineEditor from 'components/InlineEditor';
 import Truncate from 'components/Truncate';
@@ -43,13 +44,13 @@ class ListHeaderUI extends PureComponent {
     const first = list.getIn(['bookmarks', 0]);
 
     if (first) {
-      history.push(`/${collection.get('user')}/${collection.get('id')}/list/${list.get('id')}-${first.get('id')}/${first.get('timestamp')}/${first.get('url')}`);
+      history.push(`${getListLink(collection, list)}/b${first.get('id')}/${first.get('timestamp')}/${first.get('url')}`);
     }
   }
 
   viewCollection = () => {
     const { collection, history } = this.props;
-    history.push(`/${collection.get('user')}/${collection.get('id')}/pages`);
+    history.push(getCollectionLink(collection));
   }
 
   render() {
@@ -83,7 +84,7 @@ class ListHeaderUI extends PureComponent {
             success={this.props.listEdited} />
         </Truncate>
         <div className="creator">
-          Created by <Link to={`/${user}`}>{user}</Link>, with {bookmarks} from the collection <Link to={`/${user}/${collection.get('id')}`}>{collection.get('title')}</Link>
+          Created by <Link to={`/${user}`}>{user}</Link>, with {bookmarks} from the collection <Link to={getCollectionLink(collection)}>{collection.get('title')}</Link>
         </div>
         <div className="function-row">
           <Button onClick={this.startReplay} className="rounded">VIEW PAGES</Button>

--- a/frontend/src/components/collection/ListsUI/ListItem.js
+++ b/frontend/src/components/collection/ListsUI/ListItem.js
@@ -119,7 +119,7 @@ class ListItem extends PureComponent {
     const item = (
       <li className={classes} key={list.get('id')} style={{ opacity: isDragging ? 0 : 1 }}>
         <div className="wrapper">
-          <Link to={`/${collUser}/${collId}/list/${list.get('id')}`} title={list.get('title')}>
+          <Link to={`/${collUser}/${collId}/list/${list.get('slug')}`} title={list.get('title')}>
             { list.get('title') }
           </Link>
           {

--- a/frontend/src/components/collection/ListsUI/index.js
+++ b/frontend/src/components/collection/ListsUI/index.js
@@ -6,6 +6,7 @@ import { Button } from 'react-bootstrap';
 import { Link } from 'react-router-dom';
 
 import { defaultCollDesc, draggableTypes } from 'config';
+import { getCollectionLink } from 'helpers/utils';
 
 import Modal from 'components/Modal';
 import SidebarHeader from 'components/SidebarHeader';
@@ -28,7 +29,7 @@ class ListsUI extends Component {
   };
 
   static propTypes = {
-    activeListId: PropTypes.string,
+    activeListSlug: PropTypes.string,
     addToList: PropTypes.func,
     bulkAddToList: PropTypes.func,
     collection: PropTypes.object,
@@ -202,13 +203,13 @@ class ListsUI extends Component {
   goToIndex = () => {
     const { collection } = this.props;
     if (this.context.canAdmin || collection.get('public_index')) {
-      this.props.history.push(`/${collection.get('user')}/${collection.get('id')}/pages`);
+      this.props.history.push(getCollectionLink(collection, true));
     }
   }
 
   render() {
     const { canAdmin } = this.context;
-    const { activeListId, collection, list, publicIndex } = this.props;
+    const { activeListSlug, collection, list, publicIndex } = this.props;
     const { created, editModal, edited, editId, isCreating, lists, title } = this.state;
 
     // wait until collection is loaded
@@ -235,7 +236,7 @@ class ListsUI extends Component {
           onClose={this.close}>
           <div className="lists-body">
             {
-              activeListId &&
+              activeListSlug &&
                 <React.Fragment>
                   <header
                     className="collection-header"
@@ -270,7 +271,7 @@ class ListsUI extends Component {
                     index={idx}
                     key={listObj.get('id')}
                     list={listObj}
-                    selected={list && listObj.get('id') === activeListId}
+                    selected={list && listObj.get('slug') === activeListSlug}
                     saveSort={this.saveListSort}
                     sort={this.sortLists} />
                 ))
@@ -279,9 +280,9 @@ class ListsUI extends Component {
                 (publicIndex || canAdmin) &&
                   <React.Fragment>
                     <li className="divider" />
-                    <li className={classNames('all-pages', { selected: !activeListId })}>
+                    <li className={classNames('all-pages', { selected: !activeListSlug })}>
                       <div className="wrapper">
-                        <Link to={`/${collection.get('user')}/${collection.get('id')}/pages`} title="See all pages in this collection" className="button-link"><AllPagesIcon /> See all pages in this collection</Link>
+                        <Link to={getCollectionLink(collection, true)} title="See all pages in this collection" className="button-link"><AllPagesIcon /> See all pages in this collection</Link>
                         {
                           canAdmin &&
                             <button

--- a/frontend/src/components/collection/ListsUI/index.js
+++ b/frontend/src/components/collection/ListsUI/index.js
@@ -105,24 +105,24 @@ class ListsUI extends Component {
 
     if (title) {
       this.setState({ created: false, isCreating: true });
-      createList(collection.get('user'), collection.get('id'), title);
+      createList(collection.get('owner'), collection.get('id'), title);
     }
   }
 
   sendDeleteList = (listId) => {
     const { collection } = this.props;
-    this.props.deleteList(collection.get('user'), collection.get('id'), listId);
+    this.props.deleteList(collection.get('owner'), collection.get('id'), listId);
   }
 
   sendEditList = (listId, data) => {
     const { collection } = this.props;
     this.setState({ edited: false, isEditing: true, editId: listId });
-    this.props.editList(collection.get('user'), collection.get('id'), listId, data);
+    this.props.editList(collection.get('owner'), collection.get('id'), listId, data);
   }
 
   toggleIndexVisibility = () => {
     const { collection, editColl, publicIndex } = this.props;
-    editColl(collection.get('user'), collection.get('id'), { public_index: !publicIndex });
+    editColl(collection.get('owner'), collection.get('id'), { public_index: !publicIndex });
   }
 
   clearInput = () => this.setState({ title: '' })
@@ -152,7 +152,7 @@ class ListsUI extends Component {
   saveListSort = () => {
     const { collection } = this.props;
     const order = this.state.lists.map(o => o.get('id')).toArray();
-    this.props.sortLists(collection.get('user'), collection.get('id'), order);
+    this.props.sortLists(collection.get('owner'), collection.get('id'), order);
   }
 
   minimize = () => {
@@ -184,7 +184,7 @@ class ListsUI extends Component {
     // if so, bulk add selection, otherwise add single page
     if (pageSelection === null || selType === 'number' ||
         (selType === 'object' && !pageIds.includes(page.id))) {
-      this.props.addToList(collection.get('user'), collection.get('id'), list, page);
+      this.props.addToList(collection.get('owner'), collection.get('id'), list, page);
     } else {
       const pagesToAdd = [];
       for(const pgIdx of pageSelection) {
@@ -194,7 +194,7 @@ class ListsUI extends Component {
             pages.get(pgIdx).get('page').toJS()
         );
       }
-      this.props.bulkAddToList(collection.get('user'), collection.get('id'), list, pagesToAdd);
+      this.props.bulkAddToList(collection.get('owner'), collection.get('id'), list, pagesToAdd);
     }
   }
 
@@ -266,7 +266,7 @@ class ListsUI extends Component {
                   <ListItem
                     dropCallback={this.pageDropCallback}
                     collId={collection.get('id')}
-                    collUser={collection.get('user')}
+                    collUser={collection.get('owner')}
                     editList={this.sendEditList}
                     index={idx}
                     key={listObj.get('id')}

--- a/frontend/src/components/collection/PageRow/index.js
+++ b/frontend/src/components/collection/PageRow/index.js
@@ -42,7 +42,7 @@ class PageRow extends Component {
         role="button">
         <td className="timestamp"><TimeFormat dt={ts} /></td>
         <td className="bookmark-title">
-          <Link to={`/${coll.get('user')}/${coll.get('id')}/${remoteBrowserMod(browser, ts)}/${url}`}>
+          <Link to={`/${coll.get('owner')}/${coll.get('id')}/${remoteBrowserMod(browser, ts)}/${url}`}>
             {page.get('title') || 'No Title'}
           </Link>
         </td>

--- a/frontend/src/components/collection/SessionCollapsibleUI/index.js
+++ b/frontend/src/components/collection/SessionCollapsibleUI/index.js
@@ -9,6 +9,7 @@ import { List } from 'immutable';
 import { Button, Overlay, Popover } from 'react-bootstrap';
 
 import { defaultRecDesc } from 'config';
+import { getCollectionLink } from 'helpers/utils';
 
 import { getRecordingBookmarks } from 'redux/modules/recordings';
 
@@ -62,7 +63,7 @@ class SessionCollapsibleUI extends PureComponent {
   downloadAction = (evt) => {
     evt.stopPropagation();
     const { collection, recording } = this.props;
-    window.location = `/${collection.get('user')}/${collection.get('id')}/${recording.get('id')}/$download`;
+    window.location = `${getCollectionLink(collection)}/${recording.get('id')}/$download`;
   }
 
   editDescription = (txt) => {

--- a/frontend/src/components/collection/SessionCollapsibleUI/index.js
+++ b/frontend/src/components/collection/SessionCollapsibleUI/index.js
@@ -57,7 +57,7 @@ class SessionCollapsibleUI extends PureComponent {
 
   confirmDelete = () => {
     const { collection, deleteRec, recording } = this.props;
-    deleteRec(collection.get('user'), collection.get('id'), recording.get('id'));
+    deleteRec(collection.get('owner'), collection.get('id'), recording.get('id'));
   }
 
   downloadAction = (evt) => {
@@ -68,7 +68,7 @@ class SessionCollapsibleUI extends PureComponent {
 
   editDescription = (txt) => {
     const { collection, editRec, recording } = this.props;
-    editRec(collection.get('user'), collection.get('id'), recording.get('id'), { desc: txt });
+    editRec(collection.get('owner'), collection.get('id'), recording.get('id'), { desc: txt });
   }
 
   toggleDeletePopover = (evt) => {
@@ -77,7 +77,7 @@ class SessionCollapsibleUI extends PureComponent {
 
     // check if deletion will effect any lists
     if (!this.state.deletePopover) {
-      dispatch(getRecordingBookmarks(collection.get('user'), collection.get('id'), recording.get('id')));
+      dispatch(getRecordingBookmarks(collection.get('owner'), collection.get('id'), recording.get('id')));
     }
 
     this.setState({ deletePopover: !this.state.deletePopover });

--- a/frontend/src/components/controls/RemoteBrowserSelectUI/index.js
+++ b/frontend/src/components/controls/RemoteBrowserSelectUI/index.js
@@ -18,7 +18,7 @@ class RemoteBrowserSelectUI extends Component {
     active: PropTypes.bool,
     activeBookmarkId: PropTypes.string,
     activeBrowser: PropTypes.string,
-    activeListId: PropTypes.string,
+    activeList: PropTypes.string,
     browsers: PropTypes.object,
     getBrowsers: PropTypes.func,
     loading: PropTypes.bool,
@@ -56,7 +56,7 @@ class RemoteBrowserSelectUI extends Component {
   }
 
   selectBrowser = (id) => {
-    const { active, activeBookmarkId, activeListId, params, timestamp, url } = this.props;
+    const { active, activeBookmarkId, activeList, params, timestamp, url } = this.props;
     const { currMode } = this.context;
 
     this.setState({ open: false });
@@ -67,7 +67,7 @@ class RemoteBrowserSelectUI extends Component {
       if (currMode.includes('replay')) {
         // list replay
         if (activeBookmarkId) {
-          this.context.router.history.push(`/${user}/${coll}/list/${activeListId}-${activeBookmarkId}/${remoteBrowserMod(id, timestamp)}/${url}`);
+          this.context.router.history.push(`/${user}/${coll}/list/${activeList}/b${activeBookmarkId}/${remoteBrowserMod(id, timestamp)}/${url}`);
         } else {
           this.context.router.history.push(`/${user}/${coll}/${remoteBrowserMod(id, timestamp)}/${url}`);
         }

--- a/frontend/src/components/controls/ShareWidgetUI/index.js
+++ b/frontend/src/components/controls/ShareWidgetUI/index.js
@@ -68,7 +68,7 @@ class ShareWidgetUI extends Component {
 
   setPublic = () => {
     const { collection } = this.props;
-    this.props.setPublic(collection.get('user'), collection.get('id'));
+    this.props.setPublic(collection.get('owner'), collection.get('id'));
   }
 
   thirdPartyJS = () => {

--- a/frontend/src/components/controls/SidebarCollectionViewerUI/index.js
+++ b/frontend/src/components/controls/SidebarCollectionViewerUI/index.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Link } from 'react-router-dom';
 
+import { getCollectionLink, getListLink } from 'helpers/utils';
+
 import SidebarHeader from 'components/SidebarHeader';
 import Truncate from 'components/Truncate';
 import WYSIWYG from 'components/WYSIWYG';
@@ -17,7 +19,7 @@ class SidebarCollectionViewerUI extends Component {
   };
 
   static propTypes = {
-    activeListId: PropTypes.string,
+    activeList: PropTypes.string,
     collection: PropTypes.object,
     orderdPages: PropTypes.object,
     showNavigator: PropTypes.func
@@ -29,7 +31,7 @@ class SidebarCollectionViewerUI extends Component {
 
   render() {
     const { canAdmin } = this.context;
-    const { activeListId, collection } = this.props;
+    const { activeList, collection } = this.props;
 
     const lists = collection.get('lists');
     const publicIndex = collection.get('public_index');
@@ -42,7 +44,7 @@ class SidebarCollectionViewerUI extends Component {
           {
             (canAdmin || publicIndex) &&
               <nav>
-                <Link to={`/${collection.get('user')}/${collection.get('id')}/pages`}>catalog view <CatalogIcon /></Link>
+                <Link to={getCollectionLink(collection, true)}>catalog view <CatalogIcon /></Link>
               </nav>
           }
           <header className="collection-header">
@@ -59,12 +61,12 @@ class SidebarCollectionViewerUI extends Component {
           <ul>
             {
               lists.map((list) => {
-                const selected = activeListId === list.get('id');
+                const selected = activeList === list.get('slug');
                 const classes = classNames({ selected, 'is-public': list.get('public') });
                 const bk = list.getIn(['bookmarks', '0']);
                 const loc = bk ?
-                  `/${collection.get('user')}/${collection.get('id')}/list/${list.get('id')}-${bk.get('id')}/${bk.get('timestamp')}/${bk.get('url')}` :
-                  `/${collection.get('user')}/${collection.get('id')}/list/${list.get('id')}`;
+                  `${getListLink(collection, list)}/b${bk.get('id')}/${bk.get('timestamp')}/${bk.get('url')}` :
+                  getListLink(collection, list);
 
                 return (
                   <li className={classes} key={list.get('id')}>
@@ -85,12 +87,12 @@ class SidebarCollectionViewerUI extends Component {
               (publicIndex || canAdmin) && pg &&
                 <React.Fragment>
                   <li className="divider" />
-                  <li className={classNames('all-pages', { selected: !activeListId })}>
+                  <li className={classNames('all-pages', { selected: !activeList })}>
                     <div className="wrapper">
                       {
-                        !activeListId ?
+                        !activeList ?
                           <button className="borderless selected-item" onClick={this.returnToItem}><AllPagesIcon /> See all pages in this collection</button> :
-                          <Link to={`/${collection.get('user')}/${collection.get('id')}/${pg.get('timestamp')}/${pg.get('url')}`} title="Browse this collection" className="button-link"><AllPagesIcon /> See all pages in this collection</Link>
+                          <Link to={`${getCollectionLink(collection)}/${pg.get('timestamp')}/${pg.get('url')}`} title="Browse this collection" className="button-link"><AllPagesIcon /> See all pages in this collection</Link>
                       }
                     </div>
                   </li>

--- a/frontend/src/components/controls/SidebarListViewerUI/index.js
+++ b/frontend/src/components/controls/SidebarListViewerUI/index.js
@@ -131,12 +131,12 @@ class SidebarListViewer extends Component {
 
   editListTitle = (title) => {
     const { collection, list } = this.props;
-    this.props.editList(collection.get('user'), collection.get('id'), list.get('id'), { title });
+    this.props.editList(collection.get('owner'), collection.get('id'), list.get('id'), { title });
   }
 
   editListDesc = (desc) => {
     const { collection, list } = this.props;
-    this.props.editList(collection.get('user'), collection.get('id'), list.get('id'), { desc });
+    this.props.editList(collection.get('owner'), collection.get('id'), list.get('id'), { desc });
   }
 
   returnToCollection = () => this.props.showNavigator(true)

--- a/frontend/src/components/controls/SidebarListViewerUI/index.js
+++ b/frontend/src/components/controls/SidebarListViewerUI/index.js
@@ -111,7 +111,7 @@ class SidebarListViewer extends Component {
     const { collection, list } = this.props;
     this.setState({ navigated: false });
     const tsMod = remoteBrowserMod(rowData.get('browser'), rowData.get('timestamp'), '/');
-    this.context.router.history.push(`${getListLink(collection)}/b${rowData.get('id')}/${tsMod}${rowData.get('url')}`);
+    this.context.router.history.push(`${getListLink(collection, list)}/b${rowData.get('id')}/${tsMod}${rowData.get('url')}`);
   }
 
   getRowClass = ({ index }) => {
@@ -149,7 +149,7 @@ class SidebarListViewer extends Component {
         <SidebarHeader label="Collection Navigator" />
         <nav>
           <button onClick={this.returnToCollection} className="borderless">&larr; collection main</button>
-          <Link to={getListLink(collection)}>catalog view <CatalogIcon /></Link>
+          <Link to={getListLink(collection, list)}>catalog view <CatalogIcon /></Link>
         </nav>
         <header className="list-header">
           <h4>

--- a/frontend/src/components/controls/SidebarListViewerUI/index.js
+++ b/frontend/src/components/controls/SidebarListViewerUI/index.js
@@ -9,7 +9,7 @@ import { Link } from 'react-router-dom';
 import { batchActions } from 'redux-batched-actions';
 
 import { defaultListDesc, untitledEntry } from 'config';
-import { remoteBrowserMod } from 'helpers/utils';
+import { getListLink, remoteBrowserMod } from 'helpers/utils';
 
 import { setBookmarkId, updateUrlAndTimestamp } from 'redux/modules/controls';
 import { setBrowser } from 'redux/modules/remoteBrowsers';
@@ -104,14 +104,14 @@ class SidebarListViewer extends Component {
 
     // TODO: should we use router to add history changes?
     // const tsMod = remoteBrowserMod(page.get('browser'), page.get('timestamp'), '/');
-    // this.context.router.history.push(`/${collection.get('user')}/${collection.get('id')}/list/${list.get('id')}-${page.get('id')}/${tsMod}${page.get('url')}`);
+    // this.context.router.history.push(`${getListLink(collection, list)}/b${page.get('id')}/${tsMod}${page.get('url')}`);
   }
 
   onSelectRow = ({ index, rowData }) => {
     const { collection, list } = this.props;
     this.setState({ navigated: false });
     const tsMod = remoteBrowserMod(rowData.get('browser'), rowData.get('timestamp'), '/');
-    this.context.router.history.push(`/${collection.get('user')}/${collection.get('id')}/list/${list.get('id')}-${rowData.get('id')}/${tsMod}${rowData.get('url')}`);
+    this.context.router.history.push(`${getListLink(collection)}/b${rowData.get('id')}/${tsMod}${rowData.get('url')}`);
   }
 
   getRowClass = ({ index }) => {
@@ -149,7 +149,7 @@ class SidebarListViewer extends Component {
         <SidebarHeader label="Collection Navigator" />
         <nav>
           <button onClick={this.returnToCollection} className="borderless">&larr; collection main</button>
-          <Link to={`/${collection.get('user')}/${collection.get('id')}/list/${list.get('id')}`}>catalog view <CatalogIcon /></Link>
+          <Link to={getListLink(collection)}>catalog view <CatalogIcon /></Link>
         </nav>
         <header className="list-header">
           <h4>

--- a/frontend/src/components/controls/SidebarPageViewerUI/index.js
+++ b/frontend/src/components/controls/SidebarPageViewerUI/index.js
@@ -8,6 +8,7 @@ import { Link } from 'react-router-dom';
 import { batchActions } from 'redux-batched-actions';
 
 import { untitledEntry } from 'config';
+import { getCollectionLink } from 'helpers/utils';
 
 import { updateUrlAndTimestamp } from 'redux/modules/controls';
 import { setBrowser } from 'redux/modules/remoteBrowsers';
@@ -105,7 +106,7 @@ class SidebarPageViewer extends Component {
           <button onClick={this.returnToCollection} className="borderless">&larr; collection main</button>
           {
             (this.context.canAdmin || collection.get('public_index')) &&
-              <Link to={`/${collection.get('user')}/${collection.get('id')}/pages`}>catalog view <CatalogIcon /></Link>
+              <Link to={getCollectionLink(collection, true)}>catalog view <CatalogIcon /></Link>
           }
         </nav>
         <header className="pages-header">

--- a/frontend/src/containers/CollectionList/CollectionList.js
+++ b/frontend/src/containers/CollectionList/CollectionList.js
@@ -18,7 +18,7 @@ const preloadCollections = [
       const collections = state.app.get('collections');
       const { user } = params;
 
-      // if (!areCollsLoaded(state) || collections.get('user') !== user) {
+      // if (!areCollsLoaded(state) || collections.get('owner') !== user) {
       return dispatch(loadCollections(user));
       // }
 

--- a/frontend/src/containers/RemoteBrowserSelect/RemoteBrowserSelect.js
+++ b/frontend/src/containers/RemoteBrowserSelect/RemoteBrowserSelect.js
@@ -26,7 +26,7 @@ const mapStateToProps = ({ app }) => {
     accessed: remoteBrowsers.get('accessed'),
     activeBookmarkId: app.getIn(['controls', 'activeBookmarkId']),
     activeBrowser: remoteBrowsers.get('activeBrowser'),
-    activeListId: app.getIn(['controls', 'activeListId']),
+    activeList: app.getIn(['controls', 'activeList']),
     browsers: remoteBrowsers.get('browsers'),
     loaded: remoteBrowsers.get('loaded'),
     loading: remoteBrowsers.get('loading'),

--- a/frontend/src/containers/ShareWidget/index.js
+++ b/frontend/src/containers/ShareWidget/index.js
@@ -15,7 +15,8 @@ class ShareWidget extends Component {
 
   static propTypes = {
     activeBrowser: PropTypes.string,
-    activeListId: PropTypes.string,
+    activeBookmarkId: PropTypes.string,
+    activeList: PropTypes.string,
     collection: PropTypes.object,
     match: PropTypes.object,
     setCollPublic: PropTypes.func,
@@ -25,13 +26,14 @@ class ShareWidget extends Component {
   }
 
   render() {
-    const { activeBrowser, activeListId, collection, match: { params: { user, coll } }, showLoginModal, timestamp, url } = this.props;
+    const { activeBrowser, activeBookmarkId, activeList, collection,
+            match: { params: { user, coll } }, showLoginModal, timestamp, url } = this.props;
 
     const tsMod = remoteBrowserMod(activeBrowser, timestamp, '/');
-    const activeList = activeListId ? `list/${activeListId}/` : '';
+    const listFrag = activeList ? `list/${activeList}/b${activeBookmarkId}/` : '';
 
-    const shareUrl = `${appHost}/${user}/${coll}/${activeList}${tsMod}${url}`;
-    const embedUrl = `${appHost}/_embed/${user}/${coll}/${activeList}${tsMod}${url}`;
+    const shareUrl = `${appHost}/${user}/${coll}/${listFrag}${tsMod}${url}`;
+    const embedUrl = `${appHost}/_embed/${user}/${coll}/${listFrag}${tsMod}${url}`;
 
     return (
       <ShareWidgetUI
@@ -48,7 +50,8 @@ class ShareWidget extends Component {
 const mapStateToProps = ({ app }) => {
   return {
     activeBrowser: app.getIn(['remoteBrowsers', 'activeBrowser']),
-    activeListId: app.getIn(['controls', 'activeListId']),
+    activeBookmarkId: app.getIn(['controls', 'activeBookmarkId']),
+    activeList: app.getIn(['controls', 'activeList']),
     collection: app.get('collection'),
     timestamp: app.getIn(['controls', 'timestamp']),
     url: app.getIn(['controls', 'url'])

--- a/frontend/src/helpers/BaseHtml.js
+++ b/frontend/src/helpers/BaseHtml.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/no-danger*/
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import ReactDOM from 'react-dom/server';
 import serialize from 'serialize-javascript';
 import Helmet from 'react-helmet';
 

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -62,6 +62,14 @@ export function fixMalformedUrls(url) {
   return url;
 }
 
+export function getCollectionLink(coll, pages = false) {
+  return `/${coll.get('user')}/${coll.get('slug')}${pages ? '/pages' : ''}`;
+}
+
+export function getListLink(coll, list) {
+  return `${getCollectionLink(coll)}/${list.get('slug')}`;
+}
+
 export function isMS() {
   if (/(MSIE|Edge|rv:11)/i.test(navigator.userAgent)) {
     return true;

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -63,7 +63,7 @@ export function fixMalformedUrls(url) {
 }
 
 export function getCollectionLink(coll, pages = false) {
-  return `/${coll.get('user')}/${coll.get('slug')}${pages ? '/pages' : ''}`;
+  return `/${coll.get('owner')}/${coll.get('slug')}${pages ? '/pages' : ''}`;
 }
 
 export function getListLink(coll, list) {

--- a/frontend/src/helpers/utils.js
+++ b/frontend/src/helpers/utils.js
@@ -67,7 +67,7 @@ export function getCollectionLink(coll, pages = false) {
 }
 
 export function getListLink(coll, list) {
-  return `${getCollectionLink(coll)}/${list.get('slug')}`;
+  return `${getCollectionLink(coll)}/list/${list.get('slug')}`;
 }
 
 export function isMS() {

--- a/frontend/src/helpers/ws.js
+++ b/frontend/src/helpers/ws.js
@@ -199,8 +199,8 @@ class WebSocketHandler {
 
     if (this.currMode.includes('replay')) {
       if (this.params.bookmarkId) {
-        const { listId, bookmarkId } = this.params;
-        prefix = `${config.appHost}/${this.user}/${this.coll}/list/${listId}-${bookmarkId}/`;
+        const { listSlug, bookmarkId } = this.params;
+        prefix = `${config.appHost}/${this.user}/${this.coll}/list/${listSlug}/b${bookmarkId}/`;
       } else {
         prefix = `${config.appHost}/${this.user}/${this.coll}/`;
       }

--- a/frontend/src/redux/modules/collection.js
+++ b/frontend/src/redux/modules/collection.js
@@ -94,14 +94,14 @@ export default function collection(state = initialState, action = {}) {
         'public': action.result.collection.public,
         public_index,
         lists,
+        owner,
         recordings,
         size,
         slug,
         slug_matched,
         timespan,
         title,
-        updated_at,
-        user: owner,
+        updated_at
       });
     }
     case COLL_LOAD_FAIL:

--- a/frontend/src/redux/modules/collection.js
+++ b/frontend/src/redux/modules/collection.js
@@ -57,6 +57,8 @@ export default function collection(state = initialState, action = {}) {
           public_index,
           recordings,
           size,
+          slug,
+          slug_matched,
           timespan,
           title,
           updated_at
@@ -94,6 +96,8 @@ export default function collection(state = initialState, action = {}) {
         lists,
         recordings,
         size,
+        slug,
+        slug_matched,
         timespan,
         title,
         updated_at,

--- a/frontend/src/redux/modules/controls.js
+++ b/frontend/src/redux/modules/controls.js
@@ -2,7 +2,7 @@ import config from 'config';
 import { fromJS } from 'immutable';
 
 
-const ACTIVE_LIST_ID = 'wr/ctrls/ACTIVE_LIST_ID';
+const ACTIVE_LIST = 'wr/ctrls/ACTIVE_LIST';
 const SET_AUTOSCROLL = 'wr/ctrls/SET_AUTOSCROLL';
 const SET_MODE = 'wr/ctrls/SET_MODE';
 const SET_EXTRACTABLE = 'wr/ctrls/SET_EXTRACTABLE';
@@ -20,7 +20,7 @@ const GET_ARCHIVES_FAIL = 'wr/ctrls/ARCHIVES_FAIL';
 
 const initialState = fromJS({
   mode: null,
-  activeListId: null,
+  activeList: null,
   activeBookmarkId: null,
   autoscroll: false,
   extractable: null,
@@ -32,8 +32,8 @@ const initialState = fromJS({
 
 export default function controls(state = initialState, action = {}) {
   switch(action.type) {
-    case ACTIVE_LIST_ID:
-      return state.set('activeListId', action.id);
+    case ACTIVE_LIST:
+      return state.set('activeList', action.slug);
     case GET_ARCHIVES:
       return state.set('archivesLoading', true);
     case GET_ARCHIVES_SUCCESS:
@@ -110,10 +110,10 @@ export function setMode(mode) {
 }
 
 
-export function setListId(id) {
+export function setList(slug) {
   return {
-    type: ACTIVE_LIST_ID,
-    id
+    type: ACTIVE_LIST,
+    slug
   };
 }
 

--- a/frontend/src/redux/modules/list.js
+++ b/frontend/src/redux/modules/list.js
@@ -76,16 +76,18 @@ export default function list(state = initialState, action = {}) {
     case LIST_LOAD:
       return state.merge({
         loading: true,
-        loaded: false
+        loaded: false,
+        error: null
       });
     case LIST_LOAD_SUCCESS:
       return state.merge({
         loading: false,
         loaded: true,
+        error: null,
         ...action.result.list
       });
     case LIST_LOAD_FAIL:
-      return state.set('error', true);
+      return state.merge(action.error);
     case BOOKMARK_EDIT_SUCCESS:
       return state.set('bkEdited', true);
     case RESET_BOOKMARK_EDIT:

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -82,7 +82,7 @@ const userRoutes = [
     exact: true,
     footer: false,
     getLocation: ({ user, coll, list }) => {
-      return `/${user}/${coll}/list/${list.split('-')[0]}`;
+      return `/${user}/${coll}/list/${list}`;
     },
     name: 'collectionDetailList'
   }
@@ -152,7 +152,7 @@ const controllerRoutes = [
     name: 'extract'
   },
   {
-    path: `${userPath}/:coll/list/:listId([a-zA-Z0-9]+)-:bookmarkId([a-zA-Z0-9]+)/:ts([0-9]+)?$br::br([a-z0-9-:]+)/:splat(.*)`,
+    path: `${userPath}/:coll/list/:listSlug([a-zA-Z0-9-]+)/b:bookmarkId([0-9]+)/:ts([0-9]+)?$br::br([a-z0-9-:]+)/:splat(.*)`,
     classOverride: '',
     component: Replay,
     exact: true,
@@ -160,7 +160,7 @@ const controllerRoutes = [
     name: 'list rb replay'
   },
   {
-    path: `${userPath}/:coll/list/:listId([a-zA-Z0-9]+)-:bookmarkId([a-zA-Z0-9]+)/:ts([0-9]+)?/:splat(.*)`,
+    path: `${userPath}/:coll/list/:listSlug([a-zA-Z0-9-]+)/b:bookmarkId([0-9]+)/:ts([0-9]+)?/:splat(.*)`,
     classOverride: '',
     component: Replay,
     exact: true,

--- a/frontend/src/server.js
+++ b/frontend/src/server.js
@@ -61,7 +61,7 @@ app.use((req, res) => {
       </Provider>
     );
 
-    const outputHtml = ReactDOM.renderToNodeStream(
+    const outputHtml = ReactDOM.renderToString(
       <BaseHtml
         assets={webpackIsomorphicTools.assets()}
         component={component}
@@ -71,10 +71,9 @@ app.use((req, res) => {
     if (context.url) {
       res.redirect(context.status || 301, context.url);
     } else {
-      res.status(context.status ? context.status : 200);
+      res.status(context.status || 200);
       global.navigator = { userAgent: req.headers['user-agent'] };
-      res.write('<!doctype html>');
-      outputHtml.pipe(res);
+      res.send(`<!doctype html>\n ${outputHtml}`);
     }
   });
 });

--- a/webrecorder/test/test_colls_api.py
+++ b/webrecorder/test/test_colls_api.py
@@ -53,6 +53,9 @@ class TestWebRecCollsAPI(FullStackTests):
 
         assert colls[0]['id'] == 'temp'
         assert colls[0]['title'] == 'Temp'
+        assert 'pages' not in colls[0]
+        assert 'recordings' not in colls[0]
+        assert 'lists' not in colls[0]
         #assert colls[0]['download_url'] == 'http://localhost:80/{user}/temp/$download'.format(user=self.anon_user)
 
     def test_error_no_such_coll(self):

--- a/webrecorder/test/test_colls_api.py
+++ b/webrecorder/test/test_colls_api.py
@@ -33,7 +33,9 @@ class TestWebRecCollsAPI(FullStackTests):
 
         assert coll['size'] == 0
         assert coll['id'] == 'temp'
+        assert coll['slug'] == 'temp'
         assert coll['title'] == 'Temp'
+        assert coll['slug_matched'] == True
         assert coll['created_at'] <= datetime.utcnow().isoformat()
 
         assert self.ISO_DT_RX.match(coll['created_at'])

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -311,12 +311,12 @@ class TestListsAnonUserAPI(FullStackTests):
         assert 'Example Domain' in res.text
 
     def test_replay_1(self):
-        res = self.testapp.get('/{user}/temp/list/1002/mp_/http://example.com/'.format(user=self.anon_user), status=200)
+        res = self.testapp.get('/{user}/temp/list/1002/b1/mp_/http://example.com/'.format(user=self.anon_user), status=200)
         res.charset = 'utf-8'
 
         assert 'Example Domain' in res.text
 
-        assert 'wbinfo.top_url = "http://localhost:80/{user}/temp/list/1002/http://example.com/"'.format(user=self.anon_user) in res.text, res.text
+        assert 'wbinfo.top_url = "http://localhost:80/{user}/temp/list/1002/b1/http://example.com/"'.format(user=self.anon_user) in res.text, res.text
 
     # Pages
     # ========================================================================

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -287,6 +287,18 @@ class TestListsAnonUserAPI(FullStackTests):
 
         assert self.redis.hget('l:1002:info', 'public') == '1'
 
+    def test_update_list_private(self):
+        params = {'public': False}
+
+        res = self.testapp.post_json(self._format('/api/v1/list/1002?user={user}&coll=temp'), params=params)
+
+        blist = res.json['list']
+        assert blist['title'] == 'A List'
+        assert blist['id'] == '1002'
+        assert blist['public'] == False
+
+        assert self.redis.hget('l:1002:info', 'public') == '0'
+
 
     # Record, then Replay Via List
     # ========================================================================

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -249,7 +249,7 @@ class TestListsAnonUserAPI(FullStackTests):
         params = {'title': 'A List'}
         res = self.testapp.post_json(self._format('/api/v1/list/1001?user={user}&coll=temp'), params=params, status=404)
 
-    def test_update_list(self):
+    def test_update_rename_list(self):
         params = {'title': 'A List'}
 
         time.sleep(1)

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -183,10 +183,12 @@ class TestListsAPIAccess(FullStackTests):
         res = self.testapp.get('/api/v1/lists?user=another&coll=some-coll')
         assert len(res.json['lists']) == 1
         assert res.json['lists'][0]['title'] == 'Public List'
+        assert res.json['lists'][0]['slug'] == 'public-list'
 
         res = self.testapp.get('/api/v1/collection/some-coll?user=another')
         assert len(res.json['collection']['lists']) == 1
         assert res.json['collection']['lists'][0]['title'] == 'Public List'
+        assert res.json['collection']['lists'][0]['slug'] == 'public-list'
         assert res.json['collection']['featured_list'] == self.pub_list_pub_coll
 
         assert 'pages' not in res.json['collection']

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -49,7 +49,7 @@ class TestListsAPIAccess(FullStackTests):
 
         assert res.json['list']
         list_id = res.json['list']['id']
-        assert len(list_id) == 8
+        #assert len(list_id) == 8
         assert res.json['list']['public'] == public
 
         # Bookmark
@@ -59,7 +59,7 @@ class TestListsAPIAccess(FullStackTests):
                  }
 
         res = self.testapp.post_json('/api/v1/list/%s/bookmarks?user={0}&coll=some-coll'.format(user) % list_id, params=params)
-        assert len(res.json['bookmark']['id']) == 8
+        #assert len(res.json['bookmark']['id']) == 8
 
         # Another  Bookmark
         params = {'title': 'Another Bookmark',

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -461,6 +461,7 @@ class TestRegisterMigrate(FullStackTests):
         res = self.testapp.post_json('/api/v1/collection/test-migrate?user=someuser', params=params)
 
         assert res.json['collection']['id'] == 'test-coll'
+        assert res.json['collection']['slug'] == 'test-coll'
         assert res.json['collection']['title'] == 'Test Coll'
 
         assert set(self.redis.hkeys('u:someuser:colls')) == {'new-coll-3', 'new-coll', 'test-coll', 'new-coll-2'}
@@ -473,6 +474,19 @@ class TestRegisterMigrate(FullStackTests):
 
         # coll replay
         res = self.testapp.get('/someuser/test-coll/mp_/http://httpbin.org/get?food=bar')
+        res.charset = 'utf-8'
+
+        assert '"food": "bar"' in res.text, res.text
+
+    def test_orig_slug_after_rename(self):
+        res = self.testapp.get('/api/v1/collection/test-migrate?user=someuser')
+
+        assert res.json['collection']['id'] == 'test-coll'
+        assert res.json['collection']['slug'] == 'test-coll'
+        assert res.json['collection']['title'] == 'Test Coll'
+        assert res.json['collection']['slug_matched'] == False
+
+        res = self.testapp.get('/someuser/test-migrate/mp_/http://httpbin.org/get?food=bar')
         res.charset = 'utf-8'
 
         assert '"food": "bar"' in res.text, res.text

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -228,6 +228,7 @@ class TestUpload(FullStackTests):
         assert 'This is your first collection' in collection['desc']
         assert collection['id'] == 'default-collection-2'
         assert collection['title'] == 'Default Collection'
+        assert collection['slug'] == 'default-collection-2'
 
         assert collection['created_at'] == TestUpload.created_at_0
         assert collection['recordings'][0]['created_at'] == TestUpload.created_at_1
@@ -238,9 +239,11 @@ class TestUpload(FullStackTests):
         assert len(collection['lists']) == 2
         assert collection['lists'][0]['desc'] == 'List Description Goes Here!'
         assert collection['lists'][0]['title'] == 'New List'
+        assert collection['lists'][0]['slug'] == 'new-list'
 
         assert collection['lists'][1]['desc'] == 'Another List'
         assert collection['lists'][1]['title'] == 'New List 2'
+        assert collection['lists'][1]['slug'] == 'new-list-2'
 
         # Pages
         assert len(collection['pages']) == 2
@@ -308,6 +311,7 @@ class TestUpload(FullStackTests):
 
         assert "This collection doesn't yet have" in collection['desc']
         assert collection['id'] == 'temporary-collection'
+        assert collection['slug'] == 'temporary-collection'
         assert collection['title'] == 'Temporary Collection'
 
         assert collection['pages'] == [{'id': self.ID_1,

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -56,8 +56,9 @@ class CollsController(BaseController):
         def get_collections():
             user = self.get_user(api=True, redir_check=False)
 
-            kwargs = {'include_recordings': get_bool(request.query.get('include_recordings', 'true')),
-                      'include_lists': get_bool(request.query.get('include_lists', 'true'))
+            kwargs = {'include_recordings': get_bool(request.query.get('include_recordings')),
+                      'include_lists': get_bool(request.query.get('include_lists')),
+                      'include_pages': get_bool(request.query.get('include_pages')),
                      }
 
             collections = user.get_collections()

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -93,7 +93,7 @@ class CollsController(BaseController):
                 new_coll_name = self.sanitize_title(new_coll_title)
 
                 try:
-                    new_coll_name = user.rename(collection, new_coll_name)
+                    new_coll_name = user.colls.rename(collection, new_coll_name)
                 except DupeNameException as de:
                     self._raise_error(400, 'duplicate_name')
 

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -227,7 +227,11 @@ class CollsController(BaseController):
     def get_collection_info(self, coll_name, user=None, include_pages=False):
         user, collection = self.load_user_coll(user=user, coll_name=coll_name)
 
-        result = {'collection': collection.serialize(include_rec_pages=include_pages)}
+        result = {'collection': collection.serialize(include_rec_pages=include_pages,
+                                                     include_lists=True,
+                                                     include_recordings=True,
+                                                     include_pages=True,
+                                                     check_slug=coll_name)}
 
         result['user'] = user.my_id
         result['size_remaining'] = user.get_size_remaining()

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -94,7 +94,7 @@ class CollsController(BaseController):
                 new_coll_name = self.sanitize_title(new_coll_title)
 
                 try:
-                    new_coll_name = user.colls.rename(collection, new_coll_name)
+                    new_coll_name = user.colls.rename(collection, new_coll_name, allow_dupe=False)
                 except DupeNameException as de:
                     self._raise_error(400, 'duplicate_name')
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -335,9 +335,9 @@ class ContentController(BaseController, RewriterApp):
 
         # REPLAY
         # Replay List
-        @self.app.route('/<user>/<coll>/list/<list_id>/<wb_url:path>', method='ANY')
-        def do_replay_rec(user, coll, list_id, wb_url):
-            request.path_shift(4)
+        @self.app.route('/<user>/<coll>/list/<list_id>/<bk_id>/<wb_url:path>', method='ANY')
+        def do_replay_rec(user, coll, list_id, bk_id, wb_url):
+            request.path_shift(5)
 
             return self.handle_routing(wb_url, user, coll, '*', type='replay-coll')
 

--- a/webrecorder/webrecorder/listscontroller.py
+++ b/webrecorder/webrecorder/listscontroller.py
@@ -35,7 +35,7 @@ class ListsController(BaseController):
 
             self.access.assert_can_read_list(blist)
 
-            return {'list': blist.serialize()}
+            return {'list': blist.serialize(check_slug=list_id)}
 
         @self.app.post('/api/v1/list/<list_id>')
         def update_list(list_id):

--- a/webrecorder/webrecorder/listscontroller.py
+++ b/webrecorder/webrecorder/listscontroller.py
@@ -156,7 +156,7 @@ class ListsController(BaseController):
         return user, collection, self.load_list(collection, list_id)
 
     def load_list(self, collection, list_id):
-        blist = collection.get_list(list_id)
+        blist = collection.get_list_by_slug_or_id(list_id)
         if not blist:
             self._raise_error(404, 'no_such_list')
 

--- a/webrecorder/webrecorder/models/base.py
+++ b/webrecorder/webrecorder/models/base.py
@@ -23,7 +23,6 @@ class RedisUniqueComponent(object):
     def __init__(self, **kwargs):
         self.redis = kwargs['redis']
         self.my_id = kwargs.get('my_id', '')
-        self.name = kwargs.get('name', self.my_id)
         self.access = kwargs['access']
         self.owner = None
 
@@ -41,6 +40,10 @@ class RedisUniqueComponent(object):
     @property
     def size(self):
         return self.get_prop('size', force_type=int, default_val=0, force_update=True)
+
+    @property
+    def name(self):
+        return self.get_prop('slug')
 
     def incr_key(self, key, value):
         val = self.redis.hincrby(self.info_key, key, value)
@@ -240,7 +243,8 @@ class RedisNamedMap(object):
 
         self.redis.hset(comp_map, name, obj.my_id)
 
-        obj.name = name
+        #obj.name = name
+        obj['slug'] = name
 
         redir_map = self.get_redir_map()
         if redir_map:
@@ -283,7 +287,8 @@ class RedisNamedMap(object):
         self.redis.hset(comp_map, new_name, obj.my_id)
 
         old_name = obj.name
-        obj.name = new_name
+        #obj.name = new_name
+        obj.set_prop('slug', new_name)
 
         redir_map = self.get_redir_map()
         if redir_map:

--- a/webrecorder/webrecorder/models/base.py
+++ b/webrecorder/webrecorder/models/base.py
@@ -200,7 +200,7 @@ class RedisUniqueComponent(object):
 
 
 # ============================================================================
-class RedisNamedContainer(object):
+class RedisNamedMap(object):
     def __init__(self, hashmap_key, comp):
         self.hashmap_key = hashmap_key
         self.comp = comp
@@ -213,7 +213,6 @@ class RedisNamedContainer(object):
         comp_map = self.get_comp_map()
         res = self.redis.hdel(comp_map, obj.name)
 
-        self.comp.incr_size(-obj.size)
         return res
 
     def reserve_obj_name(self, name, allow_dupe=False):
@@ -239,8 +238,6 @@ class RedisNamedContainer(object):
         comp_map = self.get_comp_map()
 
         self.redis.hset(comp_map, name, obj.my_id)
-
-        self.comp.incr_size(obj.size)
 
         obj.name = name
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -202,16 +202,16 @@ class BookmarkList(RedisUniqueComponent):
         props = props or {}
 
         title = props.get('title')
-        if title:
+        if title is not None:
             self.get_owner().update_list_slug(title, self)
             self.set_prop('title', title)
 
         public = props.get('public')
-        if public:
+        if public is not None:
             self.set_public(public)
 
         desc = props.get('desc')
-        if desc:
+        if desc is not None:
             self.set_prop('desc', desc)
 
     def delete_me(self):

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -13,6 +13,8 @@ class BookmarkList(RedisUniqueComponent):
     BOOK_ORDER_KEY = 'l:{blist}:o'
     BOOK_CONTENT_KEY = 'l:{blist}:b'
 
+    BOOKMARK_COUNTER = 'c:{coll}:l:{blist}:c'
+
     def __init__(self, **kwargs):
         super(BookmarkList, self).__init__(**kwargs)
         self.bookmark_order = RedisOrderedList(self.BOOK_ORDER_KEY, self)
@@ -211,5 +213,8 @@ class BookmarkList(RedisUniqueComponent):
         return self.delete_object()
 
     def get_new_bookmark_id(self):
-        return get_new_id(8)
+        book_id = self.redis.incrby(self.BOOKMARK_COUNTER.format(coll=self.get_prop('owner'),
+                                                                 blist=self.my_id))
+        #return get_new_id(8)
+        return str(book_id)
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -28,7 +28,6 @@ class BookmarkList(RedisUniqueComponent):
 
         self.data = {'title': props['title'],
                      'desc': props.get('desc', ''),
-                     'slug': props.get('slug'),
                      'public': self._from_bool(props.get('public')),
                      'owner': self.owner.my_id,
                     }

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -28,6 +28,7 @@ class BookmarkList(RedisUniqueComponent):
 
         self.data = {'title': props['title'],
                      'desc': props.get('desc', ''),
+                     'slug': props.get('slug'),
                      'public': self._from_bool(props.get('public')),
                      'owner': self.owner.my_id,
                     }

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -33,7 +33,6 @@ class BookmarkList(RedisUniqueComponent):
                      'owner': self.owner.my_id,
                     }
 
-        self.name = str(list_id)
         self._init_new()
 
         return list_id

--- a/webrecorder/webrecorder/models/recording.py
+++ b/webrecorder/webrecorder/models/recording.py
@@ -58,6 +58,10 @@ class Recording(RedisUniqueComponent):
         cls.COMMIT_WAIT_SECS = int(config['commit_wait_secs'])
         #cls.COMMIT_WAIT_TEMPL = config['commit_wait_templ']
 
+    @property
+    def name(self):
+        return self.my_id
+
     def init_new(self, title='', desc='', rec_type=None, ra_list=None):
         rec = self._create_new_id()
 

--- a/webrecorder/webrecorder/models/user.py
+++ b/webrecorder/webrecorder/models/user.py
@@ -46,6 +46,10 @@ class User(RedisUniqueComponent):
         super(User, self).__init__(**kwargs)
         self.colls = RedisNamedMap(self.COLLS_KEY, self, self.COLLS_REDIR_KEY)
 
+    @property
+    def name(self):
+        return self.my_id
+
     def create_new(self):
         max_size = self.redis.hget('h:defaults', 'max_size')
         if not max_size:
@@ -69,7 +73,7 @@ class User(RedisUniqueComponent):
         collection = Collection(redis=self.redis,
                                 access=self.access)
 
-        coll = collection.init_new(**kwargs)
+        coll = collection.init_new(coll_name, **kwargs)
 
         self.colls.add_object(coll_name, collection, owner=True)
 


### PR DESCRIPTION
- Lists and Collection store a `slug` field, auto-computed from title
- Lists can be retrieved via slug
- When changing List and Collection `title`, the old slug is also stored to avoid breaking links
- When retrieving List or Collection object, `slug_matched` is true is using the canonical slug, otherwise should redirect
- Bookmark ids use incremental, per list counter