### PR TITLE
Importing temp data into account fixes

### DIFF
--- a/webrecorder/test/test_cdxj_cache_config.yaml
+++ b/webrecorder/test/test_cdxj_cache_config.yaml
@@ -6,7 +6,7 @@ session.secret: 'secret'
    
 session.key: __test_sesh
 
-session.key_template: test_key
+#session.key_template: test_key
 
 open_rec_ttl: 5
 coll_cdxj_ttl: 2

--- a/webrecorder/test/test_login_migrate.py
+++ b/webrecorder/test/test_login_migrate.py
@@ -202,7 +202,6 @@ class TestLoginMigrate(FullStackTests):
         assert res.json == {'deleted_user': 'test'}
 
         def assert_delete():
-            #assert not os.path.isdir(user_dir) or
             assert len(os.listdir(user_dir)) == 0
             assert not os.path.isdir(st_warcs_dir)
             assert not os.path.isdir(st_index_dir)
@@ -210,6 +209,13 @@ class TestLoginMigrate(FullStackTests):
 
         self.sleep_try(0.3, 10.0, assert_delete)
 
+    def test_delete_user_dir(self):
+        user_dir = os.path.join(self.warcs_dir, 'test')
 
+        def assert_user_dir_removed():
+            assert not os.path.isdir(user_dir)
+
+        with patch('webrecorder.rec.tempchecker.TempChecker.USER_DIR_IDLE_TIME', 1.0) as p:
+            self.sleep_try(0.5, 10.0, assert_user_dir_removed)
 
 

--- a/webrecorder/test/test_login_migrate.py
+++ b/webrecorder/test/test_login_migrate.py
@@ -5,6 +5,8 @@ import webtest
 import time
 
 from webrecorder.models.usermanager import CLIUserManager
+from webrecorder.rec.storage import get_storage
+from mock import patch
 
 
 # ============================================================================
@@ -12,7 +14,8 @@ class TestLoginMigrate(FullStackTests):
     @classmethod
     def setup_class(cls, **kwargs):
         super(TestLoginMigrate, cls).setup_class(extra_config_file='test_cdxj_cache_config.yaml',
-                                                 storage_worker=True)
+                                                 storage_worker=True,
+                                                 temp_worker=True)
 
         cls.user_manager = CLIUserManager()
 
@@ -107,7 +110,14 @@ class TestLoginMigrate(FullStackTests):
                   'moveTemp': True,
                  }
 
-        res = self.testapp.post_json('/api/v1/auth/login', params=params)
+
+        def _get_storage(storage_type, redis):
+            time.sleep(1.1)
+            return get_storage(storage_type, redis)
+
+        with patch('webrecorder.models.collection.get_global_storage', _get_storage) as p:
+            res = self.testapp.post_json('/api/v1/auth/login', params=params)
+            time.sleep(1.1)
 
         assert res.json == {'anon': False,
                             'coll_count': 2,
@@ -183,6 +193,7 @@ class TestLoginMigrate(FullStackTests):
 
     def test_delete_user(self):
         user_dir = os.path.join(self.warcs_dir, 'test')
+        anon_dir = os.path.join(self.warcs_dir, self.anon_user)
         st_warcs_dir = os.path.join(self.storage_today, 'warcs')
         st_index_dir = os.path.join(self.storage_today, 'indexes')
 
@@ -195,8 +206,10 @@ class TestLoginMigrate(FullStackTests):
             assert len(os.listdir(user_dir)) == 0
             assert not os.path.isdir(st_warcs_dir)
             assert not os.path.isdir(st_index_dir)
+            assert not os.path.isdir(anon_dir)
 
         self.sleep_try(0.3, 10.0, assert_delete)
+
 
 
 

--- a/webrecorder/test/test_no_invites_config.yaml
+++ b/webrecorder/test/test_no_invites_config.yaml
@@ -6,6 +6,3 @@ session.secret: 'secret'
    
 session.key: __test_sesh
 
-session.key_template: test_key
-
-

--- a/webrecorder/test/test_rollover_config.yaml
+++ b/webrecorder/test/test_rollover_config.yaml
@@ -8,5 +8,3 @@ session.secret: 'secret'
    
 session.key: __test_sesh
 
-session.key_template: test_key
-

--- a/webrecorder/webrecorder/rec/storage/local.py
+++ b/webrecorder/webrecorder/rec/storage/local.py
@@ -29,7 +29,11 @@ class DirectLocalFileStorage(BaseStorage):
         os.makedirs(os.path.dirname(target_url), exist_ok=True)
 
         try:
-            shutil.copyfile(full_filename, target_url)
+            if full_filename != target_url:
+                shutil.copyfile(full_filename, target_url)
+            else:
+                print('Same File')
+
             return True
         except Exception as e:
             print(e)


### PR DESCRIPTION
- Ensure temp data to be added to account is not deleted after user logs in or registers!
- When registering, extend the session (for a full 90 mins) to allow user to validate account
- Also: clear empty user directories in record directory that have not changed for a while
- Better temp data deletion: temp checker will delete expired user data the standard way, and on next pass will remove the dir and any data (if any, should be deleted by standard delete)
- Tests: add test to verify that user data is not deleted via temp checker if marked for commit and does not expire.
- Local commit: don't commit file that's already at commit location.
