### PR TITLE
session fix:

### DIFF
--- a/frontend/src/helpers/ApiClient.js
+++ b/frontend/src/helpers/ApiClient.js
@@ -14,7 +14,7 @@ function formatUrl(path) {
 }
 
 export default class ApiClient {
-  constructor(req) {
+  constructor(req, res) {
     // eslint-disable-next-line no-return-assign
     methods.forEach(method =>
       ApiClient.prototype[method] = (path, { params, data } = {}, dataType = false) => new Promise((resolve, reject) => {
@@ -47,8 +47,14 @@ export default class ApiClient {
           request.send(data);
         }
         // eslint-disable-next-line no-confusing-arrow
-        request.end((err, res) => {
-          const { body } = res;
+        request.end((err, response) => {
+          const { body } = response;
+
+          // if api sets session cookie, ensure its passed back to browser
+          const cookie = response.get('Set-Cookie');
+          if (cookie) {
+            res.set('Set-Cookie', cookie);
+          }
 
           return err || !body || body.hasOwnProperty('error') ?
             reject(body || err) :

--- a/frontend/src/server.js
+++ b/frontend/src/server.js
@@ -35,7 +35,7 @@ app.use((req, res) => {
     // hot module replacement is enabled in the development env
     webpackIsomorphicTools.refresh();
   }
-  const client = new ApiClient(req);
+  const client = new ApiClient(req, res);
   const store = createStore(client);
   const url = req.originalUrl || req.url;
   const location = parseUrl(url);

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -347,6 +347,10 @@ class RedisSessionMiddleware(CookieGuard):
                 # set redis duration
                 pi.expire(session.key, duration)
 
+        elif set_cookie:
+            # extend redis duration if extending cookie!
+            self.redis.expire(session.key, duration)
+
         if not set_cookie:
             return
 


### PR DESCRIPTION
api session: ensure redis key is extended to duration if cookie duration is extended, even if no change to session data
frontend: ensure 'Set-Cookie' header, if set, is passed from api back to browser