### PR TITLE
Optimize Page->Bookmarks Lookup

### DIFF
--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -475,6 +475,7 @@ class TestListsAnonUserAPI(FullStackTests):
         res = self._add_bookmark('1003', title='An Example 2', url='http://example.com/испытание/test',
                                  page_id=self.ID_1)
 
+        # all
         res = self.testapp.get(self._format('/api/v1/collection/temp/page_bookmarks?user={user}'))
 
         assert res.json == {'page_bookmarks': {self.ID_1: {'111': '1003', '101': '1002'}}}
@@ -488,6 +489,16 @@ class TestListsAnonUserAPI(FullStackTests):
         res = self.testapp.get(self._format('/api/v1/collection/temp/page_bookmarks?user={user}&rec=rec-none'))
 
         assert res.json == {'page_bookmarks': {}}
+
+        # all again (test cached)
+        res = self.testapp.get(self._format('/api/v1/collection/temp/page_bookmarks?user={user}'))
+
+        assert res.json == {'page_bookmarks': {self.ID_1: {'111': '1003', '101': '1002'}}}
+
+        # filter by rec again
+        res = self.testapp.get(self._format('/api/v1/collection/temp/page_bookmarks?user={user}&rec=rec'))
+
+        assert res.json == {'page_bookmarks': {self.ID_1: {'111': '1003', '101': '1002'}}}
 
     def test_coll_info_with_lists(self):
         res = self.testapp.get(self._format('/api/v1/collection/temp?user={user}'))

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -128,7 +128,7 @@ class CollsController(BaseController):
 
             rec = request.query.get('rec')
 
-            return {'page_bookmarks': collection.get_page_bookmarks(rec)}
+            return {'page_bookmarks': collection.get_all_page_bookmarks(rec)}
 
         # Create Collection
         @self.app.get('/_create')

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -59,7 +59,7 @@ class BookmarkList(RedisUniqueComponent):
         self.redis.hset(self.BOOK_CONTENT_KEY.format(blist=self.my_id), bid, json.dumps(bookmark))
 
         if page_id:
-            collection.add_page_bookmark(page_id, bid, self.my_id)
+            #collection.add_page_bookmark(page_id, bid, self.my_id)
             self.load_pages([bookmark])
 
         return bookmark
@@ -124,8 +124,8 @@ class BookmarkList(RedisUniqueComponent):
         # check if bookmark had a page_id
         bookmark = self.get_bookmark(bid)
         page_id = bookmark.get('page_id')
-        if page_id:
-            self.get_owner().remove_page_bookmark(page_id, bid)
+        #if page_id:
+        #    self.get_owner().remove_page_bookmark(page_id, bid)
 
         return self.redis.hdel(self.BOOK_CONTENT_KEY.format(blist=self.my_id), bid) == 1
 

--- a/webrecorder/webrecorder/models/list_bookmarks.py
+++ b/webrecorder/webrecorder/models/list_bookmarks.py
@@ -59,7 +59,7 @@ class BookmarkList(RedisUniqueComponent):
         self.redis.hset(self.BOOK_CONTENT_KEY.format(blist=self.my_id), bid, json.dumps(bookmark))
 
         if page_id:
-            #collection.add_page_bookmark(page_id, bid, self.my_id)
+            collection.add_page_bookmark(page_id, bid, self.my_id)
             self.load_pages([bookmark])
 
         return bookmark
@@ -124,8 +124,8 @@ class BookmarkList(RedisUniqueComponent):
         # check if bookmark had a page_id
         bookmark = self.get_bookmark(bid)
         page_id = bookmark.get('page_id')
-        #if page_id:
-        #    self.get_owner().remove_page_bookmark(page_id, bid)
+        if page_id:
+            self.get_owner().remove_page_bookmark(page_id, bid)
 
         return self.redis.hdel(self.BOOK_CONTENT_KEY.format(blist=self.my_id), bid) == 1
 

--- a/webrecorder/webrecorder/models/pages.py
+++ b/webrecorder/webrecorder/models/pages.py
@@ -5,7 +5,7 @@ import hashlib
 # ============================================================================
 class PagesMixin(object):
     PAGES_KEY = 'c:{coll}:p'
-    PAGE_BOOKMARKS_KEY = 'c:{coll}:pb'
+    PAGE_BOOKMARKS_KEY = 'c:{coll}:p_to_b'
 
     def __init__(self, **kwargs):
         super(PagesMixin, self).__init__(**kwargs)
@@ -159,6 +159,7 @@ class PagesMixin(object):
             all_pages = [page['id'] for page in all_pages]
 
         all_bookmarks = self.redis.hgetall(key)
+        # cached, load json and filter by rec_id, if needed
         if all_bookmarks:
             bookmarks = {n: json.loads(v) for n, v in all_bookmarks.items()
                          if not rec_id or n in all_pages}
@@ -169,13 +170,11 @@ class PagesMixin(object):
 
         all_bookmarks = {}
 
+        # bin all bookmarks by page
         for blist in all_lists:
             for bk in blist.get_bookmarks():
                 page_id = bk.get('page_id')
                 if not page_id:
-                    continue
-
-                if rec_id and not page_id in all_pages:
                     continue
 
                 if page_id not in all_bookmarks:

--- a/webrecorder/webrecorder/models/pages.py
+++ b/webrecorder/webrecorder/models/pages.py
@@ -132,7 +132,7 @@ class PagesMixin(object):
         key = self.PAGE_BOOKMARKS_KEY.format(coll=self.my_id, page=pid)
         self.redis.hdel(key, bid)
 
-    def get_page_bookmarks(self, rec_id=None):
+    def get_page_bookmarks2(self, rec_id=None):
         bookmarks = {}
 
         if not rec_id:
@@ -147,4 +147,30 @@ class PagesMixin(object):
             bookmarks[pid] = self.redis.hgetall(key)
 
         return bookmarks
+
+    def get_page_bookmarks(self, rec_id=None):
+        all_pages = None
+        if rec_id:
+            all_pages = self.list_rec_pages_by_id(rec_id)
+            all_pages = [page['id'] for page in all_pages]
+
+        all_lists = self.get_lists()
+        all_bookmarks = {}
+
+        for blist in all_lists:
+            for bk in blist.get_bookmarks():
+                page_id = bk.get('page_id')
+                if not page_id:
+                    continue
+
+                if rec_id and not page_id in all_pages:
+                    continue
+
+                if page_id not in all_bookmarks:
+                    all_bookmarks[page_id] = {bk['id']: blist.my_id}
+                else:
+                    all_bookmarks[page_id][bk['id']] = blist.my_id
+
+        return all_bookmarks
+
 


### PR DESCRIPTION
- Instead of storing a key for bookmarks per page, generate `c:{coll}:p_to_b` table per collection on demand, cache (same duration as collection cdxj)
- If cache key exists, update key when adding or removing bookmarks
- When deleting a page, remove from cache key, if exists