### PR TITLE
pending count improvements:

### DIFF
--- a/webrecorder/test/test_pending.py
+++ b/webrecorder/test/test_pending.py
@@ -1,0 +1,214 @@
+from .testutils import FullStackTests
+
+import os
+import gevent
+
+
+# ============================================================================
+class TestPending(FullStackTests):
+    def test_record_check_pending_1(self):
+        self.set_uuids('Recording', ['rec'])
+        url = 'http://httpbin.org/drip'
+        res = self.testapp.get('/_new/temp/rec/record/mp_/' + url)
+        assert res.headers['Location'].endswith('/' + self.anon_user + '/temp/rec/record/mp_/' + url)
+
+        def wait_for_res(res):
+            res = res.follow()
+            return res
+
+        ge_req = gevent.spawn(wait_for_res, res)
+
+        def assert_pending():
+            assert int(self.redis.hget('r:rec:info', 'pending_count')) == 2
+            assert int(self.redis.hget('r:rec:info', 'pending_size')) > 0
+
+        self.sleep_try(0.2, 4.0, assert_pending)
+
+        gevent.joinall([ge_req])
+
+        res = ge_req.value
+
+        # pending size and count should be 0
+        assert int(self.redis.hget('r:rec:info', 'pending_count')) == 0
+        assert int(self.redis.hget('r:rec:info', 'pending_size')) == 0
+        TestPending.size = int(self.redis.hget('r:rec:info', 'size'))
+        assert TestPending.size > 0
+
+    def test_record_delete_while_pending_request(self):
+        self.set_uuids('Recording', ['rec-a'])
+        url = 'http://httpbin.org/delay/2'
+        res = self.testapp.get('/_new/temp/rec-a/record/mp_/' + url)
+        assert res.headers['Location'].endswith('/' + self.anon_user + '/temp/rec-a/record/mp_/' + url)
+
+        def wait_for_res(res):
+            res = res.follow()
+            res.charset = 'utf-8'
+            return res
+
+        ge_req = gevent.spawn(wait_for_res, res)
+
+        def assert_pending():
+            # waiting for request, pending_count max of 1
+            assert int(self.redis.hget('r:rec-a:info', 'pending_count')) == 1
+            assert int(self.redis.hget('r:rec-a:info', 'pending_size')) > 0
+
+        self.sleep_try(0.2, 3.0, assert_pending)
+
+        res = self.testapp.delete('/api/v1/recording/rec-a?user={user}&coll=temp'.format(user=self.anon_user))
+
+        assert res.json == {'deleted_id': 'rec-a'}
+
+        gevent.joinall([ge_req])
+
+        res = ge_req.value
+
+        assert '"' + url + '"' in res.text, res.text
+
+        # rec info should be empty, as recording has been deleted
+        assert self.redis.hgetall('r:rec-a:info') == {}
+
+    def test_record_delete_while_pending_response(self):
+        self.set_uuids('Recording', ['rec-a'])
+        url = 'http://httpbin.org/drip'
+        res = self.testapp.get('/_new/temp/rec-a/record/mp_/' + url)
+        assert res.headers['Location'].endswith('/' + self.anon_user + '/temp/rec-a/record/mp_/' + url)
+
+        def wait_for_res(res):
+            res = res.follow()
+            return res
+
+        ge_req = gevent.spawn(wait_for_res, res)
+
+        def assert_pending():
+            # waiting for response, pending count includes request
+            assert int(self.redis.hget('r:rec-a:info', 'pending_count')) == 2
+            assert int(self.redis.hget('r:rec-a:info', 'pending_size')) > 0
+
+        self.sleep_try(0.2, 4.0, assert_pending)
+
+        res = self.testapp.delete('/api/v1/recording/rec-a?user={user}&coll=temp'.format(user=self.anon_user))
+
+        assert res.json == {'deleted_id': 'rec-a'}
+
+        gevent.joinall([ge_req])
+
+        res = ge_req.value
+        assert len(res.body) == 10
+
+        # rec info should be empty, as recording has been deleted
+        assert self.redis.hgetall('r:rec-a:info') == {}
+
+    def test_record_multiple_check_pending(self):
+        url = 'http://httpbin.org/drip'
+        self.set_uuids('Recording', ['rec-a'])
+
+        params = {'coll': 'temp',
+                  'mode': 'record',
+                  'url': url,
+                 }
+
+        res = self.testapp.post_json('/api/v1/new', params=params)
+        assert res.json['rec_name'] != ''
+
+        def assert_pending():
+            assert int(self.redis.hget('r:rec-a:info', 'pending_count')) > 0
+            assert int(self.redis.hget('r:rec-a:info', 'pending_size')) > 0
+
+        # SAME URL (DEDUP)
+        def wait_for_res(res):
+            res = self.testapp.get('/{user}/temp/rec-a/record/mp_/'.format(user=self.anon_user) + url)
+            return res
+
+        ge_reqs = [gevent.spawn(wait_for_res, res) for x in range(0, 5)]
+
+        self.sleep_try(0.2, 4.0, assert_pending)
+
+        gevent.joinall(ge_reqs)
+
+        # pending size & count should be empty
+        assert int(self.redis.hget('r:rec-a:info', 'pending_count')) == 0
+        assert int(self.redis.hget('r:rec-a:info', 'pending_size')) == 0
+
+        # assert 1 cdxj entry (deduped)
+        assert int(self.redis.zcard('r:rec-a:cdxj')) == 1
+
+        # UNIQUE URLS
+        # add param= to generate unique url
+        def wait_for_res_uniq(res, count):
+            res = self.testapp.get('/{user}/temp/rec-a/record/mp_/'.format(user=self.anon_user) + url + '?param=' + count)
+            return res
+
+        ge_reqs = [gevent.spawn(wait_for_res_uniq, res, str(x)) for x in range(0, 5)]
+
+        self.sleep_try(0.2, 4.0, assert_pending)
+
+        gevent.joinall(ge_reqs)
+
+        # pending size & count should be empty
+        assert int(self.redis.hget('r:rec-a:info', 'pending_count')) == 0
+        assert int(self.redis.hget('r:rec-a:info', 'pending_size')) == 0
+
+        # assert 6 cdxj entries
+        assert int(self.redis.zcard('r:rec-a:cdxj')) == 6
+
+        # assert collection size increased
+        coll, rec = self.get_coll_rec(self.anon_user, 'temp', '')
+        assert int(self.redis.hget('c:{0}:info'.format(coll), 'size')) > TestPending.size
+
+        # DELETE
+        res = self.testapp.delete('/api/v1/recording/rec-a?user={user}&coll=temp'.format(user=self.anon_user))
+
+        assert res.json == {'deleted_id': 'rec-a'}
+
+        def assert_deleted():
+            assert self.redis.hgetall('r:rec-a:info') == {}
+            anon_dir = os.path.join(self.warcs_dir, self.anon_user)
+            assert len(os.listdir(anon_dir)) == 1
+
+        self.sleep_try(0.2, 5.0, assert_deleted)
+
+    def test_record_multiple_delete(self):
+        url = 'http://httpbin.org/drip'
+        self.set_uuids('Recording', ['rec-b'])
+
+        params = {'coll': 'temp',
+                  'mode': 'record',
+                  'url': url,
+                 }
+
+        res = self.testapp.post_json('/api/v1/new', params=params)
+        assert res.json['rec_name'] != ''
+
+        # UNIQUE URLS
+        # add param= to generate unique url
+        def wait_for_res_uniq(res, count):
+            res = self.testapp.get('/{user}/temp/rec-b/record/mp_/'.format(user=self.anon_user) + url + '?param=' + count)
+            return res
+
+        ge_reqs = [gevent.spawn(wait_for_res_uniq, res, str(x)) for x in range(0, 5)]
+
+        def assert_pending():
+            assert int(self.redis.hget('r:rec-b:info', 'pending_count')) > 0
+            assert int(self.redis.hget('r:rec-b:info', 'pending_size')) > 0
+
+        self.sleep_try(0.2, 4.0, assert_pending)
+
+        # DELETE WHILE PENDING
+        res = self.testapp.delete('/api/v1/recording/rec-b?user={user}&coll=temp'.format(user=self.anon_user))
+
+        assert res.json == {'deleted_id': 'rec-b'}
+
+        # WAIT FOR FINISH
+        gevent.joinall(ge_reqs)
+
+        for ge in ge_reqs:
+            assert len(ge.value.body) == 10
+
+        # assert no pending data
+        assert self.redis.hgetall('r:rec-b:info') == {}
+
+    def test_user_and_coll_size(self):
+        coll, rec = self.get_coll_rec(self.anon_user, 'temp', '')
+        assert int(self.redis.hget('c:{0}:info'.format(coll), 'size')) == TestPending.size
+        assert int(self.redis.hget('u:{0}:info'.format(self.anon_user), 'size')) == TestPending.size
+

--- a/webrecorder/test/test_storage_commit.py
+++ b/webrecorder/test/test_storage_commit.py
@@ -54,7 +54,7 @@ class BaseStorageCommit(FullStackTests):
 
         assert '"food": "bar"' in res.text, res.text
 
-        self.sleep_try(0.1, 1.0, self.assert_exists(REC_CDXJ, True))
+        self.sleep_try(0.3, 10.0, self.assert_exists(REC_CDXJ, True))
 
     def test_record_2_temp(self):
         res = self.testapp.get('/_new/default-collection/rec/record/mp_/http://httpbin.org/get?food=bar')
@@ -64,7 +64,7 @@ class BaseStorageCommit(FullStackTests):
 
         assert '"food": "bar"' in res.text, res.text
 
-        self.sleep_try(0.1, 1.0, self.assert_exists(REC_CDXJ, True))
+        self.sleep_try(0.5, 10.0, self.assert_exists(REC_CDXJ, True))
 
     def test_delete_rec(self):
         user_dir = os.path.join(self.warcs_dir, 'test')

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -221,7 +221,7 @@ class TestUpload(FullStackTests):
             assert res.json['done'] == True
             assert res.json['size'] >= res.json['total_size']
 
-        self.sleep_try(0.1, 5.0, assert_finished)
+        self.sleep_try(0.2, 10.0, assert_finished)
 
     def test_logged_in_replay(self):
         res = self.testapp.get('/test/default-collection-2/mp_/http://httpbin.org/get?food=bar')
@@ -311,7 +311,7 @@ class TestUpload(FullStackTests):
             assert res.json['done'] == True
             assert res.json['size'] >= res.json['total_size']
 
-        self.sleep_try(0.1, 5.0, assert_finished)
+        self.sleep_try(0.2, 10.0, assert_finished)
 
     def test_replay_2(self):
         res = self.testapp.get('/test/temporary-collection/mp_/http://example.com/')
@@ -360,7 +360,7 @@ class TestUpload(FullStackTests):
             assert res.json['done'] == True
             assert res.json['size'] >= res.json['total_size']
 
-        self.sleep_try(0.1, 5.0, assert_finished)
+        self.sleep_try(0.2, 10.0, assert_finished)
 
     def test_coll_info_replay_3(self):
         res = self.testapp.get('/api/v1/collection/default-collection?user=test')

--- a/webrecorder/webrecorder/rec/tempchecker.py
+++ b/webrecorder/webrecorder/rec/tempchecker.py
@@ -44,12 +44,19 @@ class TempChecker(object):
 
         if sesh == 'commit-wait':
             try:
+                if not os.path.isdir(temp_dir):
+                    print('Remove Session For Already Deleted Dir: ' + temp_dir)
+                    self.sesh_redis.delete(temp_key)
+                    return True
+
                 print('Removing if empty: ' + temp_dir)
                 os.rmdir(temp_dir)
                 #shutil.rmtree(temp_dir)
                 print('Deleted empty dir: ' + temp_dir)
+
+                self.sesh_redis.delete(temp_key)
+
             except Exception as e:
-                #print(e)
                 print('Waiting for commit')
                 return False
 


### PR DESCRIPTION
- ensure 'pending_size' and 'pending_count' only updated if recording session still exists/is open
- recorderapp: move create_write_buffer() to writer, ensure recording open key expiry is extended while continuing to read data
- tests: add pending_size/count tests to ensure proper update, update for concurrent writers, at 0 after all requests done, and no further update if recording session deleted while recording
- tests: update sleep wait timeouts on storage and upload tests to avoid appveyor failures?