### PR TITLE
stats improvements (per day):

### DIFF
--- a/webrecorder/test/test_extract.py
+++ b/webrecorder/test/test_extract.py
@@ -109,6 +109,6 @@ class TestExtractContent(FullStackTests):
         assert self.redis.exists(Stats.SOURCES_KEY.format('ia'))
         assert int(self.redis.hget(Stats.SOURCES_KEY.format('ia'), today_str())) > 0
 
-        assert not self.redis.exists(Stats.PATCH_USAGE_KEY)
+        assert not self.redis.exists(Stats.PATCH_TEMP_KEY)
 
 

--- a/webrecorder/test/test_patch.py
+++ b/webrecorder/test/test_patch.py
@@ -62,5 +62,5 @@ class TestPatchContent(FullStackTests):
         assert self.redis.exists(Stats.SOURCES_KEY.format('ia'))
         assert int(self.redis.hget(Stats.SOURCES_KEY.format('ia'), today_str())) > 0
 
-        assert int(self.redis.hget(Stats.PATCH_USAGE_KEY, today_str())) > 0
+        assert int(self.redis.hget(Stats.PATCH_TEMP_KEY, today_str())) > 0
 

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -413,8 +413,8 @@ class TestUpload(FullStackTests):
         assert res.json == {'error': 'not_logged_in'}
 
     def test_stats(self):
-        assert self.redis.hget(Stats.DOWNLOADS_KEY, today_str()) == '1'
-        assert self.redis.hget(Stats.UPLOADS_KEY, today_str()) == '3'
+        assert self.redis.hget(Stats.DOWNLOADS_USER_COUNT_KEY, today_str()) == '1'
+        assert self.redis.hget(Stats.UPLOADS_COUNT_KEY, today_str()) == '3'
 
 
 

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -76,8 +76,8 @@ class CollsController(BaseController):
             user, collection = self.load_user_coll(coll_name=coll_name)
 
             errs = user.remove_collection(collection, delete=True)
-            if errs:
-                return errs
+            if errs.get('error'):
+                return self._raise_error(400, errs['error'])
             else:
                 return {'deleted_id': coll_name}
 

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -315,8 +315,11 @@ class Collection(PagesMixin, RedisUniqueComponent):
 
         return get_global_storage(storage_type, self.redis)
 
+    def get_created_iso_date(self):
+        return date.fromtimestamp(int(self['created_at'])).isoformat()
+
     def get_dir_path(self):
-        return date.fromtimestamp(int(self['created_at'])).isoformat() + '/' + self.my_id
+        return self.get_created_iso_date() + '/' + self.my_id
 
     def sync_coll_index(self, exists=False, do_async=False):
         coll_cdxj_key = self.COLL_CDXJ_KEY.format(coll=self.my_id)

--- a/webrecorder/webrecorder/models/user.py
+++ b/webrecorder/webrecorder/models/user.py
@@ -8,6 +8,7 @@ from webrecorder.utils import redis_pipeline
 from webrecorder.models.base import RedisUniqueComponent, RedisNamedMap
 
 from webrecorder.models.collection import Collection
+from webrecorder.models.stats import Stats
 
 
 # ============================================================================
@@ -127,6 +128,8 @@ class User(RedisUniqueComponent):
 
         self.incr_size(-collection.size)
         new_user.incr_size(collection.size)
+
+        Stats(self.redis).move_temp_to_user_usage(collection)
 
         for recording in collection.get_recordings():
             # will be marked for commit

--- a/webrecorder/webrecorder/recscontroller.py
+++ b/webrecorder/webrecorder/recscontroller.py
@@ -55,8 +55,8 @@ class RecsController(BaseController):
             user, collection, recording = self.load_recording(rec)
 
             errs = collection.remove_recording(recording, delete=True)
-            if errs:
-                return errs
+            if errs.get('error'):
+                return self._raise_error(400, errs['error'])
             else:
                 return {'deleted_id': rec}
 

--- a/webrecorder/webrecorder/uploadcontroller.py
+++ b/webrecorder/webrecorder/uploadcontroller.py
@@ -40,7 +40,7 @@ class UploadController(BaseController):
             if 'error' in res:
                 return self._raise_error(400, res['error'])
 
-            Stats(self.redis).incr_upload(user)
+            Stats(self.redis).incr_upload(user, expected_size)
             return res
 
         @self.app.get('/_upload/<upload_id>')


### PR DESCRIPTION
- all capture (record + patch + extract), logged in and anon
- delete logged in and anon
- patch logged in and anon
- download (size and counts) logged in and anon
- upload size and count
- remote browser count
- remote archive count

delete api:
- return 400 if delete failed (eg. already deleted)
- if single file delete failed, still delete, return 200, but add file to retry queue