### PR TITLE
More stats

### DIFF
--- a/webrecorder/test/test_anon_workflow.py
+++ b/webrecorder/test/test_anon_workflow.py
@@ -45,6 +45,7 @@ class TestTempContent(FullStackTests):
         'h:defaults',
         'h:roles',
         Stats.ALL_CAPTURE_TEMP_KEY,
+        Stats.REPLAY_TEMP_KEY,
         Stats.DELETE_TEMP_KEY,
         Stats.DOWNLOADS_TEMP_SIZE_KEY,
         Stats.DOWNLOADS_TEMP_COUNT_KEY,
@@ -120,7 +121,7 @@ class TestTempContent(FullStackTests):
 
         if replay_coll:
             exp_keys.append('c:{coll}:cdxj'.format(user=user, coll=coll))
-            #exp_keys.append('c:{coll}:warc'.format(user=user, coll=coll))
+            exp_keys.append(Stats.REPLAY_TEMP_KEY)
 
         if self.downloaded:
             exp_keys.append(Stats.DOWNLOADS_TEMP_COUNT_KEY)

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -5,6 +5,8 @@ import time
 from mock import patch
 
 from webrecorder.models.list_bookmarks import BookmarkList
+from webrecorder.models.stats import Stats
+from webrecorder.utils import today_str
 
 
 # ============================================================================
@@ -613,4 +615,14 @@ class TestListsAnonUserAPI(FullStackTests):
 
         assert len(self.redis.keys('l:*')) == 0
         assert len(self.redis.keys('b:*')) == 0
+
+    # Stats
+    # ========================================================================
+    def test_stats(self):
+        assert self.redis.hget(Stats.BOOKMARK_ADD_KEY, today_str()) == '11'
+        assert self.redis.hget(Stats.BOOKMARK_MOD_KEY, today_str()) == '1'
+
+        # only includes explicit deletions or from list deletion
+        assert self.redis.hget(Stats.BOOKMARK_DEL_KEY, today_str()) == '3'
+
 

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -2,6 +2,9 @@ from .testutils import BaseWRTests, FullStackTests
 from webrecorder.models.usermanager import CLIUserManager
 from webrecorder.utils import sanitize_title
 
+from webrecorder.models.stats import Stats
+from webrecorder.utils import today_str
+
 
 # ============================================================================
 class TestListsAPIAccess(FullStackTests):
@@ -235,4 +238,6 @@ class TestListsAPIAccess(FullStackTests):
         res = self.testapp.post_json('/api/v1/list/{0}?user=another&coll=some-coll'.format(self.priv_list_pub_coll), status=404, params={'title': 'Foo'})
         res = self.testapp.post_json('/api/v1/list/{0}?user=another&coll=some-coll'.format(self.pub_list_pub_coll), status=404, params={'title': 'Foo'})
 
+    def test_stats(self):
+        assert self.redis.hget(Stats.BOOKMARK_ADD_KEY, today_str()) == '8'
 

--- a/webrecorder/test/test_login_migrate.py
+++ b/webrecorder/test/test_login_migrate.py
@@ -6,6 +6,10 @@ import time
 
 from webrecorder.models.usermanager import CLIUserManager
 from webrecorder.rec.storage import get_storage
+
+from webrecorder.models.stats import Stats
+from webrecorder.utils import today_str
+
 from mock import patch
 
 
@@ -218,5 +222,8 @@ class TestLoginMigrate(FullStackTests):
 
         with patch('webrecorder.rec.tempchecker.TempChecker.USER_DIR_IDLE_TIME', 1.0) as p:
             self.sleep_try(0.5, 10.0, assert_user_dir_removed)
+
+    def test_stats(self):
+        assert self.redis.hget(Stats.TEMP_MOVE_KEY, today_str()) == '1'
 
 

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -685,7 +685,19 @@ class TestRegisterMigrate(FullStackTests):
         self.sleep_try(0.3, 10.0, assert_delete)
 
     def test_stats(self):
-        assert self.redis.hget(Stats.TEMP_MOVE_KEY, today_str()) == '1'
+        today = today_str()
+        assert self.redis.hget(Stats.TEMP_MOVE_KEY, today) == '1'
+
+        keys = set(self.redis.keys('st:*'))
+        assert keys == {
+            Stats.TEMP_MOVE_KEY,
+            Stats.ALL_CAPTURE_TEMP_KEY,
+            Stats.ALL_CAPTURE_USER_KEY,
+            Stats.REPLAY_USER_KEY,
+            Stats.DOWNLOADS_USER_COUNT_KEY,
+            Stats.DOWNLOADS_USER_SIZE_KEY,
+            Stats.DELETE_USER_KEY
+        }
 
     def test_login_4_no_such_user(self):
         params = {'username': 'someuser',

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -8,6 +8,9 @@ from pywb.recorder.multifilewarcwriter import MultiFileWARCWriter
 from webrecorder.models.usermanager import CLIUserManager
 from webrecorder.rec.storage import get_storage
 
+from webrecorder.models.stats import Stats
+from webrecorder.utils import today_str
+
 import re
 import os
 import time
@@ -680,6 +683,9 @@ class TestRegisterMigrate(FullStackTests):
             assert not os.path.isdir(st_index_dir)
 
         self.sleep_try(0.3, 10.0, assert_delete)
+
+    def test_stats(self):
+        assert self.redis.hget(Stats.TEMP_MOVE_KEY, today_str()) == '1'
 
     def test_login_4_no_such_user(self):
         params = {'username': 'someuser',

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -862,15 +862,21 @@ class ContentController(BaseController, RewriterApp):
                 'inv_sources': kwargs.get('inv_sources'),
                }
 
-    def _add_custom_params(self, cdx, resp_headers, kwargs):
+    def _add_custom_params(self, cdx, resp_headers, kwargs, record):
         try:
-            self._add_stats(cdx, resp_headers, kwargs)
+            self._add_stats(cdx, resp_headers, kwargs, record)
         except:
             import traceback
             traceback.print_exc()
 
-    def _add_stats(self, cdx, resp_headers, kwargs):
+    def _add_stats(self, cdx, resp_headers, kwargs, record):
         type_ = kwargs['type']
+
+        if type_ == 'replay-coll':
+            content_len = record.rec_headers.get_header('Content-Length')
+            if content_len is not None:
+                Stats(self.redis).incr_replay(int(content_len), kwargs['user'])
+
         if type_ in ('record', 'live'):
             return
 

--- a/webrecorder/webrecorder/models/stats.py
+++ b/webrecorder/webrecorder/models/stats.py
@@ -14,6 +14,9 @@ class Stats(object):
     ALL_CAPTURE_USER_KEY = 'st:all-capture-user'
     ALL_CAPTURE_TEMP_KEY = 'st:all-capture-temp'
 
+    REPLAY_USER_KEY = 'st:replay-user'
+    REPLAY_TEMP_KEY = 'st:replay-temp'
+
     PATCH_USER_KEY = 'st:patch-user'
     PATCH_TEMP_KEY = 'st:patch-temp'
 
@@ -158,6 +161,14 @@ class Stats(object):
 
     def incr_bookmark_del(self):
         self.redis.hincrby(self.BOOKMARK_DEL_KEY, today_str(), 1)
+
+    def incr_replay(self, size, username):
+        if username.startswith(self.TEMP_PREFIX):
+            key = self.REPLAY_TEMP_KEY
+        else:
+            key = self.REPLAY_USER_KEY
+
+        self.redis.hincrby(key, today_str(), size)
 
     def move_temp_to_user_usage(self, collection):
         date_str = collection.get_created_iso_date()


### PR DESCRIPTION
Additional stats to track:
- bookmark add, modify, delete
- count of temp collection added to account
- replay traffic: count WARC record length, bucket by day, temp vs logged in users
- requires latest pywb 2.0.4 build for _add_custom_params() change