### PR TITLE
clear content session when in app/content domain mode:

### DIFF
--- a/frontend/src/redux/modules/auth.js
+++ b/frontend/src/redux/modules/auth.js
@@ -109,6 +109,6 @@ export function incrementCollCount(incr) {
 export function logout() {
   return {
     types: [LOGOUT, LOGOUT_SUCCESS, LOGOUT_FAIL],
-    promise: client => client.get(`${config.apiPath}/auth/logout`)
+    promise: client => client.post(`${config.apiPath}/auth/logout`)
   };
 }

--- a/webrecorder/test/test_api_user_login.py
+++ b/webrecorder/test/test_api_user_login.py
@@ -128,7 +128,7 @@ class TestApiUserLogin(FullStackTests):
         assert res.json == {'error': 'already_registered'}
 
     def test_api_logout(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
         assert res.json['success']
 
         assert self.testapp.cookies.get('__test_sesh', '') == ''
@@ -181,6 +181,14 @@ class TestApiUserLogin(FullStackTests):
     def test_login_fail_wrong_user(self):
         params = {'username': 'someuser2',
                   'password': 'Password2'}
+
+        res = self.testapp.post_json('/api/v1/auth/login', params=params, status=401)
+
+        assert res.json == {'error': 'invalid_login'}
+        assert self.testapp.cookies.get('__test_sesh', '') == ''
+
+    def test_login_fail_no_params(self):
+        params = {'foo': 'bar'}
 
         res = self.testapp.post_json('/api/v1/auth/login', params=params, status=401)
 
@@ -250,7 +258,7 @@ class TestApiUserLogin(FullStackTests):
         assert res.json == {'success': True}
 
     def test_logout_2(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
         assert res.json['success']
 
         assert self.testapp.cookies.get('__test_sesh', '') == ''

--- a/webrecorder/test/test_lists_multi_user.py
+++ b/webrecorder/test/test_lists_multi_user.py
@@ -106,7 +106,7 @@ class TestListsAPIAccess(FullStackTests):
         assert res.json['collection']['recordings'] == []
 
     def test_logout_login_user_2(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
 
         params = {'username': 'another',
                   'password': 'TestTest456',
@@ -178,7 +178,7 @@ class TestListsAPIAccess(FullStackTests):
         res = self.testapp.get('/api/v1/lists?user=test&coll=some-coll', status=404)
 
     def test_public_list_private_coll_error_logged_out(self):
-        res = self.testapp.get('/api/v1/auth/logout')
+        res = self.testapp.post('/api/v1/auth/logout')
 
         res = self.testapp.get('/api/v1/lists?user=test&coll=some-coll', status=404)
 

--- a/webrecorder/test/test_login_migrate.py
+++ b/webrecorder/test/test_login_migrate.py
@@ -177,7 +177,7 @@ class TestLoginMigrate(FullStackTests):
             assert self.storage_today in result[key]
 
     def test_logout_1(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
         assert res.json['success']
 
         assert self.testapp.cookies.get('__test_sesh', '') == ''

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -399,7 +399,7 @@ class TestRegisterMigrate(FullStackTests):
         assert '"rec": "test"' in res.text
 
     def test_logout_1(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
         assert res.json['success']
         assert self.testapp.cookies.get('__test_sesh', '') == ''
 
@@ -572,7 +572,7 @@ class TestRegisterMigrate(FullStackTests):
         assert self.testapp.cookies.get('__test_sesh', '') != ''
 
     def test_logout_2(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
         assert res.json['success']
         assert self.testapp.cookies.get('__test_sesh', '') == ''
 
@@ -616,7 +616,7 @@ class TestRegisterMigrate(FullStackTests):
         assert res.json == {'error': 'no_such_collection'}
 
     def test_logout_3(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
         assert res.json['success']
         assert self.testapp.cookies.get('__test_sesh', '') == ''
 

--- a/webrecorder/test/test_upload.py
+++ b/webrecorder/test/test_upload.py
@@ -399,7 +399,7 @@ class TestUpload(FullStackTests):
         assert len(res.json['collection']['recordings']) == 3
 
     def test_logout_1(self):
-        res = self.testapp.get('/api/v1/auth/logout', status=200)
+        res = self.testapp.post('/api/v1/auth/logout', status=200)
         assert res.json['success']
         assert self.testapp.cookies.get('__test_sesh', '') == ''
 

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -29,7 +29,7 @@ class BaseController(object):
     def init_routes(self):
         raise NotImplemented()
 
-    def redir_host(self, host=None, path=None):
+    def redir_host(self, host=None, path=None, status=None):
         if not host:
             host = self.app_host
 
@@ -43,7 +43,7 @@ class BaseController(object):
                 path += '?' + request.query_string
 
         url += path
-        return bottle_redirect(url)
+        return bottle_redirect(url, code=status)
 
     def validate_csrf(self):
         csrf = request.forms.getunicode('csrf')

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -404,15 +404,18 @@ class ContentController(BaseController, RewriterApp):
                 self._raise_error(400, 'invalid_request')
 
     def set_options_headers(self, origin_host, target_host):
-        expected_origin = request.environ['wsgi.url_scheme'] + '://' + origin_host
         origin = request.environ.get('HTTP_ORIGIN')
-        # ensure origin is the content host origin
-        if origin != expected_origin:
-            return False
+
+        if origin_host:
+            expected_origin = request.environ['wsgi.url_scheme'] + '://' + origin_host
+
+            # ensure origin is the content host origin
+            if origin != expected_origin:
+                return False
 
         host = request.environ.get('HTTP_HOST')
         # ensure host is the app host
-        if host != target_host:
+        if target_host and host != target_host:
             return False
 
         response.headers['Access-Control-Allow-Origin'] = origin

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -71,7 +71,7 @@ class ContentController(BaseController, RewriterApp):
 
     def get_csp_header(self):
         csp = "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: "
-        if self.content_host != self.app_host:
+        if self.app_host and self.content_host != self.app_host:
             csp += self.app_host + '/_set_session'
 
         csp += "; form-action 'self'"
@@ -358,7 +358,7 @@ class ContentController(BaseController, RewriterApp):
             return self.handle_routing(wb_url, user, coll, '*', type='replay-coll')
 
         # Session redir
-        @self.app.route(['/_set_session'])
+        @self.app.get(['/_set_session'])
         def set_sesh():
             sesh = self.get_session()
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -369,7 +369,7 @@ class ContentController(BaseController, RewriterApp):
 
             else:
                 url = request.environ['wsgi.url_scheme'] + '://' + self.content_host
-                response.headers['Access-Control-Allow-Origin'] = url
+                self.set_options_headers(self.content_host, self.app_host)
                 response.headers['Cache-Control'] = 'no-cache'
 
                 redirect(url + '/_set_session?' + request.environ['QUERY_STRING'] + '&id=' + quote(sesh.get_id()))
@@ -377,33 +377,20 @@ class ContentController(BaseController, RewriterApp):
         # OPTIONS
         @self.app.route('/_set_session', method='OPTIONS')
         def set_sesh_options():
-            expected_origin = request.environ['wsgi.url_scheme'] + '://' + self.content_host + '/'
-            origin = request.environ.get('HTTP_ORIGIN')
-            # ensure origin is the content host origin
-            if origin != expected_origin:
-                return ''
+            self.set_options_headers(self.content_host, self.app_host)
+            return ''
 
-            host = request.environ.get('HTTP_HOST')
-            # ensure host is the app host
-            if host != self.app_host:
-                return ''
-
-            response.headers['Access-Control-Allow-Origin'] = origin
-
-            methods = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_METHOD')
-            if methods:
-                response.headers['Access-Control-Allow-Methods'] = methods
-
-            headers = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
-            if headers:
-                response.headers['Access-Control-Allow-Headers'] = headers
-
-            response.headers['Access-Control-Allow-Credentials'] = 'true'
+        @self.app.route('/_clear_session', method='OPTIONS')
+        def set_clear_options():
+            self.set_options_headers(self.app_host, self.content_host)
             return ''
 
         # CLEAR CONTENT SESSION
         @self.app.get(['/_clear_session'])
         def clear_sesh():
+            self.set_options_headers(self.app_host, self.content_host)
+            response.headers['Cache-Control'] = 'no-cache'
+
             if not self.is_content_request():
                 self._raise_error(400, 'invalid_request')
 
@@ -415,6 +402,32 @@ class ContentController(BaseController, RewriterApp):
 
             except Exception as e:
                 self._raise_error(400, 'invalid_request')
+
+    def set_options_headers(self, origin_host, target_host):
+        expected_origin = request.environ['wsgi.url_scheme'] + '://' + origin_host
+        origin = request.environ.get('HTTP_ORIGIN')
+        # ensure origin is the content host origin
+        if origin != expected_origin:
+            return False
+
+        host = request.environ.get('HTTP_HOST')
+        # ensure host is the app host
+        if host != target_host:
+            return False
+
+        response.headers['Access-Control-Allow-Origin'] = origin
+
+        methods = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_METHOD')
+        if methods:
+            response.headers['Access-Control-Allow-Methods'] = methods
+
+        headers = request.environ.get('HTTP_ACCESS_CONTROL_REQUEST_HEADERS')
+        if headers:
+            response.headers['Access-Control-Allow-Headers'] = headers
+
+        response.headers['Access-Control-Allow-Credentials'] = 'true'
+        response.headers['Access-Control-Max-Age'] = '1800'
+        return True
 
     def do_proxy(self, url):
         info = self.browser_mgr.init_cont_browser_sesh()

--- a/webrecorder/webrecorder/models/usermanager.py
+++ b/webrecorder/webrecorder/models/usermanager.py
@@ -201,8 +201,8 @@ class UserManager(object):
 
     def login_user(self, input_data):
         """Authenticate users"""
-        username = input_data.get('username')
-        password = input_data.get('password')
+        username = input_data.get('username', '')
+        password = input_data.get('password', '')
 
         try:
             move_info = self.get_move_temp_info(input_data)


### PR DESCRIPTION
- when logging in, out or deleting user, redirect to <content host>/_clear_session
to clear content host cookie
- convert /api/v1/logout from get to post for additional security
- tests: add tests for clear session redirect, _clear_session call, updated to post to login
- frontend: switch to using post for logout