### PR TITLE
Stats and csp

### DIFF
--- a/webrecorder/test/test_app_content_domain.py
+++ b/webrecorder/test/test_app_content_domain.py
@@ -90,7 +90,7 @@ class TestAppContentDomain(FullStackTests):
         res = self.content_get('/{user}/temp/mp_/http://httpbin.org/get?food=bar')
         assert '"food": "bar"' in res.text
 
-        csp = "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: app-host/_set_session; form-action 'self'"
+        csp = "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: app-host/_set_session; frame-ancestors app-host; form-action 'self'"
         assert res.headers['Content-Security-Policy'] == csp
 
     def test_redir_to_content_frame(self):

--- a/webrecorder/test/test_app_content_domain.py
+++ b/webrecorder/test/test_app_content_domain.py
@@ -90,7 +90,7 @@ class TestAppContentDomain(FullStackTests):
         res = self.content_get('/{user}/temp/mp_/http://httpbin.org/get?food=bar')
         assert '"food": "bar"' in res.text
 
-        csp = "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: app-host/_set_session; frame-ancestors app-host; form-action 'self'"
+        csp = "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: app-host/_set_session; form-action 'self'"
         assert res.headers['Content-Security-Policy'] == csp
 
     def test_redir_to_content_frame(self):

--- a/webrecorder/test/test_login_migrate.py
+++ b/webrecorder/test/test_login_migrate.py
@@ -224,6 +224,7 @@ class TestLoginMigrate(FullStackTests):
             self.sleep_try(0.5, 10.0, assert_user_dir_removed)
 
     def test_stats(self):
-        assert self.redis.hget(Stats.TEMP_MOVE_KEY, today_str()) == '1'
-
+        today = today_str()
+        assert int(self.redis.hget(Stats.TEMP_MOVE_COUNT_KEY, today)) == 1
+        assert int(self.redis.hget(Stats.TEMP_MOVE_SIZE_KEY, today)) > 0
 

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -686,11 +686,13 @@ class TestRegisterMigrate(FullStackTests):
 
     def test_stats(self):
         today = today_str()
-        assert self.redis.hget(Stats.TEMP_MOVE_KEY, today) == '1'
+        assert int(self.redis.hget(Stats.TEMP_MOVE_COUNT_KEY, today)) == 1
+        assert int(self.redis.hget(Stats.TEMP_MOVE_SIZE_KEY, today)) > 0
 
         keys = set(self.redis.keys('st:*'))
         assert keys == {
-            Stats.TEMP_MOVE_KEY,
+            Stats.TEMP_MOVE_COUNT_KEY,
+            Stats.TEMP_MOVE_SIZE_KEY,
             Stats.ALL_CAPTURE_TEMP_KEY,
             Stats.ALL_CAPTURE_USER_KEY,
             Stats.REPLAY_USER_KEY,

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -73,6 +73,7 @@ class ContentController(BaseController, RewriterApp):
         csp = "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: "
         if self.app_host and self.content_host != self.app_host:
             csp += self.app_host + '/_set_session'
+            csp += '; frame-ancestors ' + self.app_host
 
         csp += "; form-action 'self'"
         return csp

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -396,10 +396,9 @@ class ContentController(BaseController, RewriterApp):
                 self._raise_error(400, 'invalid_request')
 
             try:
-                res = json.loads(request.query.getunicode('json'))
                 # delete session (will updated cookie)
                 self.get_session().delete()
-                return res
+                return {'success': 'logged_out'}
 
             except Exception as e:
                 self._raise_error(400, 'invalid_request')

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -73,7 +73,6 @@ class ContentController(BaseController, RewriterApp):
         csp = "default-src 'unsafe-eval' 'unsafe-inline' 'self' data: blob: mediastream: ws: wss: "
         if self.app_host and self.content_host != self.app_host:
             csp += self.app_host + '/_set_session'
-            csp += '; frame-ancestors ' + self.app_host
 
         csp += "; form-action 'self'"
         return csp

--- a/webrecorder/webrecorder/models/stats.py
+++ b/webrecorder/webrecorder/models/stats.py
@@ -9,7 +9,8 @@ from pywb.warcserver.index.cdxobject import CDXObject
 class Stats(object):
     TEMP_PREFIX = 'temp-'
 
-    TEMP_MOVE_KEY = 'st:temp-moves'
+    TEMP_MOVE_COUNT_KEY = 'st:temp-moves'
+    TEMP_MOVE_SIZE_KEY = 'st:temp-moves-size'
 
     ALL_CAPTURE_USER_KEY = 'st:all-capture-user'
     ALL_CAPTURE_TEMP_KEY = 'st:all-capture-temp'
@@ -171,9 +172,11 @@ class Stats(object):
         self.redis.hincrby(key, today_str(), size)
 
     def move_temp_to_user_usage(self, collection):
+        today = today_str()
         date_str = collection.get_created_iso_date()
         size = collection.size
         with redis_pipeline(self.redis) as pi:
-            pi.hincrby(self.TEMP_MOVE_KEY, today_str(), 1)
-            pi.hincrby(self.ALL_CAPTURE_TEMP_KEY, date_str, -size)
+            pi.hincrby(self.TEMP_MOVE_COUNT_KEY, today, 1)
+            pi.hincrby(self.TEMP_MOVE_SIZE_KEY, today, size)
             pi.hincrby(self.ALL_CAPTURE_USER_KEY, date_str, size)
+            pi.hincrby(self.ALL_CAPTURE_TEMP_KEY, date_str, -size)

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -46,12 +46,6 @@ class UserController(BaseController):
 
         return user
 
-    def check_clear_session_redirect(self, data):
-        if self.content_host and self.app_host != self.content_host:
-            param_str = urlencode({'json': json.dumps(data)})
-            self.redir_host(self.content_host, '/_clear_session?' + param_str, status=303)
-
-
     def init_routes(self):
         # USER CHECKS
         @self.app.get('/api/v1/auth/check_username/<username>')
@@ -123,7 +117,6 @@ class UserController(BaseController):
                 if result.get('new_coll_name'):
                     data['new_coll_name'] = result['new_coll_name']
 
-                self.check_clear_session_redirect(data)
                 return data
 
             #self._raise_error(401, result.get('error', ''))
@@ -137,7 +130,6 @@ class UserController(BaseController):
             self.user_manager.logout()
 
             data = {'success': 'logged_out'}
-            self.check_clear_session_redirect(data)
 
             return data
 
@@ -224,7 +216,6 @@ class UserController(BaseController):
                 return self._raise_error(400, 'error_deleting')
 
             data = {'deleted_user': username}
-            self.check_clear_session_redirect(data)
             return data
 
         @self.app.post('/api/v1/user/<username>/desc')


### PR DESCRIPTION
- Add new stat for size of temp data moved to user account
- ~Add frame-ancestors to csp policy~ Blocks embedding WR, so had to remove
- Remove: redirect to _clear_session on login/logout/delete (breaks IE11, doesn't actually clear the session w/o extra credentials headers!)