### PR TITLE
bugreporter improvement:

### DIFF
--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -472,6 +472,21 @@ class TestRegisterMigrate(FullStackTests):
 
         assert '"food": "bar"' in res.text, res.text
 
+    def test_rename_coll_invalid_name(self):
+        # empty title
+        params = {'title': ''}
+        res = self.testapp.post_json('/api/v1/collection/test-migrate?user=someuser', params=params, status=400)
+
+        assert res.json['error'] == 'invalid_coll_name'
+
+        # title that results in empty slug
+        params = {'title': '@$%'}
+        res = self.testapp.post_json('/api/v1/collection/test-migrate?user=someuser', params=params, status=400)
+
+        assert res.json['error'] == 'invalid_coll_name'
+
+        assert set(self.redis.hkeys('u:someuser:colls')) == {'new-coll-3', 'new-coll', 'test-migrate', 'new-coll-2'}
+
     def test_rename_coll(self):
         params = {'title': 'Test Coll'}
         res = self.testapp.post_json('/api/v1/collection/test-migrate?user=someuser', params=params)

--- a/webrecorder/webrecorder/bugreportcontroller.py
+++ b/webrecorder/webrecorder/bugreportcontroller.py
@@ -34,7 +34,16 @@ class BugReportController(BaseController):
         @self.app.post('/api/v1/report/dnlr')
         def report_issues():
             useragent = request.headers.get('User-Agent')
-            self.do_report(request.json, useragent)
+            data = request.json or {}
+            self.do_report(data, useragent)
+            return {}
+
+        @self.app.post('/api/v1/report/ui')
+        def report_issues():
+            useragent = request.headers.get('User-Agent')
+            data = request.json or {}
+            data['state'] = 'ui-report'
+            self.do_report(data, useragent)
             return {}
 
     def do_report(self, params, ua=''):

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -93,6 +93,9 @@ class CollsController(BaseController):
                 new_coll_title = data['title']
                 new_coll_name = self.sanitize_title(new_coll_title)
 
+                if not new_coll_name:
+                    self._raise_error(400, 'invalid_coll_name')
+
                 try:
                     new_coll_name = user.colls.rename(collection, new_coll_name, allow_dupe=False)
                 except DupeNameException as de:

--- a/webrecorder/webrecorder/gh_reporter.py
+++ b/webrecorder/webrecorder/gh_reporter.py
@@ -5,7 +5,7 @@ from werkzeug.useragents import UserAgent
 
 
 
-template = """
+DNLR_TEMPLATE = """
 Test in New Recording: **[{actual_url}]({record_url})**
 
 User Reported Url: **[{url}]({url})**
@@ -25,6 +25,23 @@ Additional Info:
 Specific Issues:
 
 """
+
+
+UI_TEMPLATE = """
+
+Report Source Url: **[{url}]({url})**
+
+Time: **{time}**
+
+Browser: **{ua_platform} {ua_browser} {ua_version}**
+
+Contact Email: {email}
+
+Issue Description:
+{desc}
+
+"""
+
 
 
 # ============================================================================
@@ -156,13 +173,26 @@ class GitHubIssueImporter(object):
         else:
             report['email'] = ''
 
-        if not report.get('state'):
-            report['state'] = '-'
+        state = report.get('state')
 
-        if report.get('desc'):
-            labels.append('has-additional-info')
+        # UI Bug Report
+        if state == 'ui-report':
+            labels.append('ui-report')
 
-        body = template.format(**report)
+            body = UI_TEMPLATE.format(**report)
+
+            title = '[UI Report] ' + report['url']
+
+        else:
+            if not report.get('state'):
+                report['state'] = '-'
+
+            if report.get('desc'):
+                labels.append('has-additional-info')
+
+            body = DNLR_TEMPLATE.format(**report)
+
+            title = report['actual_url'][:255]
 
         for prop in self.PROP_LABELS.keys():
             if report.get(prop):
@@ -170,8 +200,9 @@ class GitHubIssueImporter(object):
                 labels.append(prop)
 
         issue = {'body': body,
-                 'title': report['actual_url'][:255],
-                 'labels': labels}
+                 'title': title,
+                 'labels': labels,
+                }
 
         return issue
 

--- a/webrecorder/webrecorder/models/base.py
+++ b/webrecorder/webrecorder/models/base.py
@@ -278,6 +278,9 @@ class RedisNamedMap(object):
             return self.redis.hget(redir_map, obj_name)
 
     def rename(self, obj, new_name, allow_dupe=True):
+        if not new_name:
+            return None
+
         new_name = self.reserve_obj_name(new_name, allow_dupe=allow_dupe)
 
         comp_map = self.get_comp_map()

--- a/webrecorder/webrecorder/models/usermanager.py
+++ b/webrecorder/webrecorder/models/usermanager.py
@@ -259,7 +259,12 @@ class UserManager(object):
     def get_user_email(self, user):
         if not user:
             return ''
-        user_data = self.all_users[user]
+
+        try:
+            user_data = self.all_users[user]
+        except:
+            user_data = None
+
         if user_data:
             return user_data.get('email_addr', '')
         else:


### PR DESCRIPTION
- add support for ui reporting via /api/v1/report/ui
- Add simplified bug report template with 'ui-report' issue, '[UI Report]' in title
- usermanager: ensure get_user_email() returns empty string for non-existent user

collection api fix:
- don't allow renaming collection to empty slug/name, return 400 'invalid_coll_name' if slug is empty