### PR TITLE
Auto Gen Backend Assets

### DIFF
--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -46,6 +46,9 @@ from webrecorder.basecontroller import BaseController
 
 from wsgiprox.wsgiprox import WSGIProxMiddleware
 
+from webrecorder.standalone.assetsutils import default_build
+import gevent
+
 
 # ============================================================================
 class MainController(BaseController):
@@ -71,6 +74,7 @@ class MainController(BaseController):
             self.static_root = os.path.join(sys._MEIPASS, 'webrecorder', 'static/')
         else:
             self.static_root = resource_filename('webrecorder', 'static/')
+            gevent.spawn(default_build, force_build=False)
 
         bottle_app = Bottle()
         self.bottle_app = bottle_app

--- a/webrecorder/webrecorder/standalone/hooks/hook-webrecorder.py
+++ b/webrecorder/webrecorder/standalone/hooks/hook-webrecorder.py
@@ -1,7 +1,7 @@
 from PyInstaller.utils.hooks import collect_data_files, copy_metadata
 import os
 
-from webrecorder.standalone.assetsutils import build
+from webrecorder.standalone.assetsutils import build_all
 from webrecorder.standalone.versionbuild import get_version_str
 
 def rename(old, new, t):
@@ -11,7 +11,7 @@ def rename(old, new, t):
 # Build webassets bundle
 curr_path = os.path.dirname(__file__)
 assets_path = os.path.abspath(os.path.join(curr_path, '..', '..', 'config', 'assets.yaml'))
-build(assets_path)
+build_all(assets_path)
 
 datas = []
 


### PR DESCRIPTION
Ensure backend `static/bundle` assets are generated automatically on launch, primarily used for `pywb.js` and `proxy.js`