### PR TITLE
Add external collection api:

### DIFF
--- a/webrecorder/test/test_colls_api.py
+++ b/webrecorder/test/test_colls_api.py
@@ -65,6 +65,27 @@ class TestWebRecCollsAPI(FullStackTests):
         assert 'lists' not in colls[0]
         #assert colls[0]['download_url'] == 'http://localhost:80/{user}/temp/$download'.format(user=self.anon_user)
 
+    def test_error_no_title(self):
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), status=400)
+
+        assert res.json['error'] == 'invalid_coll_name'
+
+    def test_error_invalid_temp_title(self):
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user),
+                                     params={'title': 'new'}, status=400)
+
+        assert res.json['error'] == 'invalid_temp_coll_name'
+
+    def test_error_external_not_allowed(self):
+        params = {'external': True,
+                  'title': 'temp'
+                 }
+
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), params=params,
+                                     status=403)
+
+        assert res.json == {'error': 'external_not_allowed'}
+
     def test_error_no_such_coll(self):
         res = self.testapp.get('/api/v1/collection/blah@$?user={user}'.format(user=self.anon_user), status=404)
         assert res.json == {'error': 'no_such_collection'}

--- a/webrecorder/test/test_external.py
+++ b/webrecorder/test/test_external.py
@@ -1,0 +1,48 @@
+from .testutils import FullStackTests
+
+import os
+
+
+# ============================================================================
+class TestExternalColl(FullStackTests):
+    @classmethod
+    def setup_class(cls):
+        os.environ['ALLOW_EXTERNAL'] = '1'
+        super(TestExternalColl, cls).setup_class()
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestExternalColl, cls).teardown_class()
+        os.environ.pop('ALLOW_EXTERNAL', '')
+
+    def test_external_init(self):
+        params = {'external': True,
+                  'title': 'external'
+                 }
+
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), params=params)
+
+        assert res.json['collection']['slug'] == 'external'
+
+    def test_external_set_cdx(self):
+        cdx = """\
+com,example)/ 20180306181354 http://example.com/ text/html 200 A6DESOVDZ3WLYF57CS5E4RIC4ARPWRK7 - - 1214 773 test.warc.gz
+com,example)/fake 20180306181354 http://example.com/fake text/html 200 A6DESOVDZ3WLYF57CS5E4RIC4ARPWRK7 - - 1214 773 test.warc.gz
+"""
+        res = self.testapp.put('/api/v1/collection/external/cdx?user={user}'.format(user=self.anon_user), params=cdx)
+
+        assert res.json['success'] == 2
+
+    def test_external_set_warc(self):
+        warc_path = 'file://' + os.path.join(self.get_curr_dir(), 'warcs', 'test_3_15_upload.warc.gz')
+
+        res = self.testapp.put_json('/api/v1/collection/external/warc?user={user}'.format(user=self.anon_user),
+                                    params={'warcs': {'test.warc.gz': warc_path}})
+
+        assert res.json['success'] == 1
+
+    def test_replay(self):
+        res = self.testapp.get('/{user}/external/mp_/http://example.com/'.format(user=self.anon_user))
+
+        assert 'Example Domain' in res.text
+

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -79,9 +79,9 @@ class BaseController(object):
         if not coll_name:
             self._raise_error(400, 'no_collection_specified')
 
-        if self.access.is_anon(user):
-            if coll_name != 'temp':
-                self._raise_error(404, 'no_such_collection')
+        #if self.access.is_anon(user):
+        #    if coll_name != 'temp':
+        #        self._raise_error(404, 'no_such_collection')
 
         collection = user.get_collection_by_name(coll_name)
         if not collection:


### PR DESCRIPTION
- if 'ALLOW_EXTERNAL' env var is set to truthy value, allow temporary, external collections
- external collections created with 'external' flag on /api/v1/collections
- external collections do not have recordings and do not delete data
- warc mapping and cdx for external collections can be added with PUT /api/v1/collection/<name>/warc and PUT /api/v1/collection/<name>/cdx
- warc mapping must be accessible to webrecorder, eg. local mount, external http:// url
- external collections can be added to temp users only and can have any name, not just 'temp'
- tests: add test for external collection replay, verify only available if ALLOW_EXTERNAL=1