### PR TITLE
DAT Share Support

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,6 @@ services:
         environment:
             - PORT=3282
             - ROOT_DIR=/data/storage
-            - DB_DIR=/data/dat/
 
         ports:
             - "3282:3282/tcp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
             - recorder
             - redis
             - shepherd
+            - dat
 
         volumes:
             - ./webrecorder/:/code/
@@ -41,6 +42,21 @@ services:
 
         ports:
             - 8096:8096 # for HMR on dev
+
+    dat:
+        image: webrecorder/dat-share
+        environment:
+            - PORT=3282
+            - ROOT_DIR=/data/storage
+            - DB_DIR=/data/dat/
+
+        ports:
+            - "3282:3282/tcp"
+            - "3282:3282/udp"
+
+        volumes:
+            - ./data:/data
+            - ./data/dat/secret_keys:/root/.dat/secret_keys
 
     recorder:
         build: ./webrecorder
@@ -117,6 +133,7 @@ services:
         volumes:
             - /var/run/docker.sock:/var/run/docker.sock
 
+
     redis:
         build: ./redis
 
@@ -137,6 +154,7 @@ services:
         environment:
             - "maildomain=localhost"
             - "smtp_user=test:archive"
+
 
 networks:
     default:

--- a/webrecorder/setup.py
+++ b/webrecorder/setup.py
@@ -109,6 +109,7 @@ setup(
         'pytest-cov',
         'fakeredis',
         'mock',
+        'responses',
         'httpbin==0.5.0'
        ],
     cmdclass={'test': PyTest,

--- a/webrecorder/test/test_browser_init.py
+++ b/webrecorder/test/test_browser_init.py
@@ -7,6 +7,7 @@ from mock import patch
 
 from webrecorder.utils import today_str
 from webrecorder.models.stats import Stats
+from webrecorder.browsermanager import BrowserManager
 
 
 # ============================================================================
@@ -33,9 +34,16 @@ class TestBrowserInit(FullStackTests):
     @classmethod
     def setup_class(cls):
         with patch('webrecorder.browsermanager.BrowserManager.load_all_browsers', mock_load_all_browsers):
+            os.environ['NO_REMOTE_BROWSERS'] = '0'
             super(TestBrowserInit, cls).setup_class()
 
         cls.browser_redis = FakeStrictRedis.from_url(os.environ['REDIS_BROWSER_URL'], decode_responses=True)
+
+    @classmethod
+    def teardown_class(cls):
+        os.environ.pop('NO_REMOTE_BROWSERS', '')
+        BrowserManager.running = False
+        super(TestBrowserInit, cls).teardown_class()
 
     def test_create_coll_and_rec(self):
         res = self._anon_post('/api/v1/collections?user={user}', params={'title': 'temp'})

--- a/webrecorder/test/test_dat_api.py
+++ b/webrecorder/test/test_dat_api.py
@@ -32,9 +32,9 @@ class TestDatShare(FullStackTests):
 
     @classmethod
     def teardown_class(cls):
-        super(TestDatShare, cls).teardown_class()
         os.environ.pop('ALLOW_DAT', '')
-        DatShare.dat_share.running = False
+        DatShare.dat_share.close()
+        super(TestDatShare, cls).teardown_class()
 
     def test_init_coll_and_user(self):
         res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), params={'title': 'temp'})

--- a/webrecorder/test/test_dat_api.py
+++ b/webrecorder/test/test_dat_api.py
@@ -1,0 +1,210 @@
+from .testutils import FullStackTests
+
+import os
+import time
+import json
+import yaml
+
+from webrecorder.models.usermanager import CLIUserManager
+from webrecorder.models.datshare import DatShare
+from webrecorder.utils import get_new_id, today_str
+import responses
+
+from itertools import count
+
+
+# ============================================================================
+class TestDatShare(FullStackTests):
+    COLL_ID = '100'
+
+    @classmethod
+    def setup_class(cls):
+        os.environ['AUTO_LOGIN_USER'] = 'test'
+        os.environ['ALLOW_DAT'] = '1'
+        os.environ['DAT_SYNC_CHECK_TIME'] = '30'
+
+        super(TestDatShare, cls).setup_class(storage_worker=True)
+
+        cls.manager = CLIUserManager()
+        cls.set_uuids('Collection', count(int(cls.COLL_ID)))
+
+        cls.dat_info = {'datKey': get_new_id(size=20),
+                        'discoveryKey': get_new_id(size=20)
+                       }
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestDatShare, cls).teardown_class()
+        os.environ.pop('ALLOW_DAT', '')
+        os.environ.pop('AUTO_LOGIN_USER', '')
+
+    def test_create_user_def_coll(self):
+        self.manager.create_user('test@example.com', 'test', 'TestTest123', 'archivist', 'Test')
+        res = self.testapp.get('/test/default-collection')
+        res.charset = 'utf-8'
+        assert '"test"' in res.text
+
+    def test_record_1(self):
+        res = self.testapp.get('/_new/default-collection/rec/record/mp_/http://httpbin.org/get?food=bar')
+        assert res.status_code == 302
+        res = res.follow()
+        res.charset = 'utf-8'
+
+        assert '"food": "bar"' in res.text, res.text
+
+    def test_commit_1(self):
+        self.params = {}
+
+        def assert_committed():
+            res = self.testapp.post_json('/api/v1/collection/default-collection/commit?user=test', params=self.params)
+            self.params = res.json
+            assert self.params['success'] == True
+
+        self.sleep_try(0.2, 10.0, assert_committed)
+
+    @responses.activate
+    def test_dat_share(self):
+        responses.add(responses.POST, 'http://dat:3000/init', status=200,
+                      json=self.dat_info)
+
+        responses.add(responses.POST, 'http://dat:3000/share', status=200,
+                      json=self.dat_info)
+
+        params = {'collDir': self.warcs_dir}
+        res = self.testapp.post_json('/api/v1/collection/default-collection/dat/share?user=test', params=params)
+        assert res.json == self.dat_info
+
+        assert len(responses.calls) == 2
+        assert responses.calls[0].request.url == 'http://dat:3000/init'
+        assert responses.calls[1].request.url == 'http://dat:3000/share'
+
+        today = today_str()
+        storage_dir = os.path.join(self.storage_dir, today, self.COLL_ID)
+
+        # test dat.json
+        with open(os.path.join(storage_dir, 'dat.json'), 'rt') as fh:
+            datjson = json.loads(fh.read())
+
+        assert datjson['url'] == 'dat://' + self.dat_info['datKey']
+        assert datjson['author'] == 'Test'
+        assert datjson['title'] == 'Default Collection'
+        assert datjson['desc'].startswith('*This is your first collection')
+
+        # test metadata.yaml
+        with open(os.path.join(storage_dir, 'metadata', 'metadata.yaml'), 'rt') as fh:
+            metadata = yaml.load(fh.read())
+
+        assert metadata['collection']
+        assert 'pages' in metadata['collection']
+        assert 'recordings' in metadata['collection']
+        assert 'lists' in metadata['collection']
+
+    @responses.activate
+    def test_dat_already_shared(self):
+        params = {'collDir': self.warcs_dir}
+        res = self.testapp.post_json('/api/v1/collection/default-collection/dat/share?user=test', params=params, status=400)
+
+        assert res.json == {'error': 'already_updated'}
+
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_dat_unshare(self):
+        responses.add(responses.POST, 'http://dat:3000/unshare', status=200,
+                      json={'success': True})
+
+        params = {'collDir': self.warcs_dir}
+        res = self.testapp.post_json('/api/v1/collection/default-collection/dat/unshare?user=test', params=params)
+        assert res.json == {'success': True}
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == 'http://dat:3000/unshare'
+
+    @responses.activate
+    def test_dat_unshare_not_sharing(self):
+        params = {'collDir': self.warcs_dir}
+        res = self.testapp.post_json('/api/v1/collection/default-collection/dat/unshare?user=test', params=params)
+        assert res.json == {'success': True}
+
+        assert len(responses.calls) == 0
+
+    @responses.activate
+    def test_dat_reshare_upstream_api_error(self):
+        responses.add(responses.POST, 'http://dat:3000/share', status=400,
+                      json={'error': 'unknown'})
+
+        params = {'collDir': self.warcs_dir}
+        res = self.testapp.post_json('/api/v1/collection/default-collection/dat/share?user=test', params=params,
+                                     status=400)
+
+        assert res.json == {'error': 'api_error'}
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == 'http://dat:3000/share'
+
+    @responses.activate
+    def test_dat_reshare(self):
+        responses.add(responses.POST, 'http://dat:3000/share', status=200,
+                      json=self.dat_info)
+
+        params = {'collDir': self.warcs_dir}
+        res = self.testapp.post_json('/api/v1/collection/default-collection/dat/share?user=test', params=params)
+        assert res.json == self.dat_info
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == 'http://dat:3000/share'
+
+    @responses.activate
+    def test_dat_sync_check_in_sync(self):
+        responses.add(responses.GET, 'http://dat:3000/numDats', status=200,
+                      json={'num': 1})
+
+        DatShare.dat_share.dat_sync()
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == 'http://dat:3000/numDats'
+
+
+    @responses.activate
+    def test_dat_sync_check_sync_needed(self):
+        responses.add(responses.GET, 'http://dat:3000/numDats', status=200,
+                      json={'num': 0})
+
+        responses.add(responses.POST, 'http://dat:3000/sync', status=200,
+                      json={'results': [self.dat_info]})
+
+        DatShare.dat_share.dat_sync()
+
+        assert len(responses.calls) == 2
+        assert responses.calls[0].request.url == 'http://dat:3000/numDats'
+        assert responses.calls[1].request.url == 'http://dat:3000/sync'
+
+        body = json.loads(responses.calls[1].request.body.decode('utf-8'))
+        assert body == {'dirs': [today_str() + '/' + self.COLL_ID]}
+
+
+    @responses.activate
+    def test_dat_unshare_on_coll_delete(self):
+        responses.add(responses.POST, 'http://dat:3000/unshare', status=200,
+                      json={'success': True})
+
+        res = self.testapp.delete('/api/v1/collection/default-collection?user=test')
+        assert res.json == {'deleted_id': 'default-collection'}
+
+        assert len(responses.calls) == 1
+        assert responses.calls[0].request.url == 'http://dat:3000/unshare'
+
+        body = json.loads(responses.calls[0].request.body.decode('utf-8'))
+        assert body == {'collDir': today_str() + '/' + self.COLL_ID}
+
+        assert self.redis.hlen(DatShare.DAT_COLLS) == 0
+
+    def test_ensure_coll_delete(self):
+        today = today_str()
+        storage_dir = os.path.join(self.storage_dir, today, self.COLL_ID)
+
+        def wait_for_del():
+            assert not os.path.isdir(storage_dir)
+
+        self.sleep_try(0.1, 2.0, wait_for_del)
+

--- a/webrecorder/test/test_pending.py
+++ b/webrecorder/test/test_pending.py
@@ -22,7 +22,7 @@ class TestPending(FullStackTests):
             assert int(self.redis.hget('r:rec:info', 'pending_count')) == 2
             assert int(self.redis.hget('r:rec:info', 'pending_size')) > 0
 
-        self.sleep_try(0.2, 4.0, assert_pending)
+        self.sleep_try(0.2, 10.0, assert_pending)
 
         gevent.joinall([ge_req])
 
@@ -52,7 +52,7 @@ class TestPending(FullStackTests):
             assert int(self.redis.hget('r:rec-a:info', 'pending_count')) == 1
             assert int(self.redis.hget('r:rec-a:info', 'pending_size')) > 0
 
-        self.sleep_try(0.2, 3.0, assert_pending)
+        self.sleep_try(0.2, 10.0, assert_pending)
 
         res = self.testapp.delete('/api/v1/recording/rec-a?user={user}&coll=temp'.format(user=self.anon_user))
 
@@ -84,7 +84,7 @@ class TestPending(FullStackTests):
             assert int(self.redis.hget('r:rec-a:info', 'pending_count')) == 2
             assert int(self.redis.hget('r:rec-a:info', 'pending_size')) > 0
 
-        self.sleep_try(0.2, 4.0, assert_pending)
+        self.sleep_try(0.2, 10.0, assert_pending)
 
         res = self.testapp.delete('/api/v1/recording/rec-a?user={user}&coll=temp'.format(user=self.anon_user))
 
@@ -121,7 +121,7 @@ class TestPending(FullStackTests):
 
         ge_reqs = [gevent.spawn(wait_for_res, res) for x in range(0, 5)]
 
-        self.sleep_try(0.2, 4.0, assert_pending)
+        self.sleep_try(0.2, 10.0, assert_pending)
 
         gevent.joinall(ge_reqs)
 
@@ -140,7 +140,7 @@ class TestPending(FullStackTests):
 
         ge_reqs = [gevent.spawn(wait_for_res_uniq, res, str(x)) for x in range(0, 5)]
 
-        self.sleep_try(0.2, 4.0, assert_pending)
+        self.sleep_try(0.2, 10.0, assert_pending)
 
         gevent.joinall(ge_reqs)
 
@@ -165,7 +165,7 @@ class TestPending(FullStackTests):
             anon_dir = os.path.join(self.warcs_dir, self.anon_user)
             assert len(os.listdir(anon_dir)) == 1
 
-        self.sleep_try(0.2, 5.0, assert_deleted)
+        self.sleep_try(0.2, 10.0, assert_deleted)
 
     def test_record_multiple_delete(self):
         url = 'http://httpbin.org/drip'
@@ -191,7 +191,7 @@ class TestPending(FullStackTests):
             assert int(self.redis.hget('r:rec-b:info', 'pending_count')) > 0
             assert int(self.redis.hget('r:rec-b:info', 'pending_size')) > 0
 
-        self.sleep_try(0.2, 4.0, assert_pending)
+        self.sleep_try(0.2, 10.0, assert_pending)
 
         # DELETE WHILE PENDING
         res = self.testapp.delete('/api/v1/recording/rec-b?user={user}&coll=temp'.format(user=self.anon_user))

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -69,6 +69,8 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
         cls.set_nx_env('EMAIL_SENDER', 'test@localhost')
         cls.set_nx_env('EMAIL_SMTP_URL', 'smtp://webrectest@mail.localhost:test@localhost:25')
 
+        cls.set_nx_env('NO_REMOTE_BROWSERS', '1')
+
         def load_wr_config():
             config = load_overlay_config('WR_CONFIG', 'pkg://webrecorder/config/wr.yaml', 'WR_USER_CONFIG', '')
             config['dyn_stats_key_templ'] = {

--- a/webrecorder/webrecorder/browsermanager.py
+++ b/webrecorder/webrecorder/browsermanager.py
@@ -3,6 +3,7 @@ import gevent
 from bottle import request
 
 from webrecorder.models.stats import Stats
+from webrecorder.utils import get_bool
 
 import socket
 import os
@@ -10,6 +11,8 @@ import os
 
 # ============================================================================
 class BrowserManager(object):
+    running = True
+
     def __init__(self, config, browser_redis, user_manager):
         self.browser_redis = browser_redis
 
@@ -17,8 +20,9 @@ class BrowserManager(object):
         self.browser_list_url = config['browser_list_url']
         self.browsers = {}
 
-        if not os.environ.get('NO_REMOTE_BROWSERS'):
+        if not get_bool(os.environ.get('NO_REMOTE_BROWSERS')):
             self.load_all_browsers()
+
             gevent.spawn(self.browser_load_loop)
 
         self.user_manager = user_manager
@@ -37,7 +41,7 @@ class BrowserManager(object):
         return self.browsers
 
     def browser_load_loop(self):
-        while True:
+        while self.running:
             gevent.sleep(300)
             self.load_all_browsers()
 

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -194,7 +194,11 @@ class CollsController(BaseController):
         def dat_do_share(coll_name):
             user, collection = self.load_user_coll(coll_name=coll_name)
 
-            result = DatShare.dat_share(collection, share=True, author=user.name)
+            try:
+                result = DatShare.dat_share.share(collection)
+            except Exception as e:
+                result = {'error': 'api_error', 'details': str(e)}
+
             if 'error' in result:
                 self._raise_error(400, result['error'])
 
@@ -204,11 +208,27 @@ class CollsController(BaseController):
         def dat_do_unshare(coll_name):
             user, collection = self.load_user_coll(coll_name=coll_name)
 
-            result = DatShare.dat_share(collection, share=False)
+            try:
+                result = DatShare.dat_share.unshare(collection)
+            except Exception as e:
+                result = {'error': 'api_error', 'details': str(e)}
+
             if 'error' in result:
                 self._raise_error(400, result['error'])
 
             return result
+
+        @self.app.post('/api/v1/collection/<coll_name>/commit')
+        def commit_file(coll_name):
+            user, collection = self.load_user_coll(coll_name=coll_name)
+
+            data = request.json or {}
+
+            res = collection.commit_all(data.get('commit_id'))
+            if not res:
+                return {'success': True}
+            else:
+                return {'commit_id': res}
 
         # Create Collection
         #@self.app.get('/_create')

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -6,6 +6,7 @@ from webrecorder.basecontroller import BaseController
 from webrecorder.webreccork import ValidationException
 
 from webrecorder.models.base import DupeNameException
+from webrecorder.models.datshare import DatShare
 from webrecorder.utils import get_bool
 
 
@@ -17,6 +18,7 @@ class CollsController(BaseController):
 
         self.allow_external = get_bool(os.environ.get('ALLOW_EXTERNAL', False))
 
+        self.dat_share = DatShare()
 
     def init_routes(self):
         @self.app.post('/api/v1/collections')
@@ -189,6 +191,27 @@ class CollsController(BaseController):
 
             return {'page_bookmarks': collection.get_all_page_bookmarks(rec_pages)}
 
+        # DAT
+        @self.app.post('/api/v1/collection/<coll_name>/dat/share')
+        def dat_share(coll_name):
+            user, collection = self.load_user_coll(coll_name=coll_name)
+
+            result = self.dat_share(user, collection, share=True)
+            if 'error' in result:
+                self._raise_error(400, result['error'])
+
+            return result
+
+        @self.app.post('/api/v1/collection/<coll_name>/dat/unshare')
+        def dat_share(coll_name):
+            user, collection = self.load_user_coll(coll_name=coll_name)
+
+            result = self.dat_share(user, collection, share=False)
+            if 'error' in result:
+                self._raise_error(400, result['error'])
+
+            return result
+
         # Create Collection
         #@self.app.get('/_create')
         #@self.jinja2_view('create_collection.html')
@@ -296,3 +319,4 @@ class CollsController(BaseController):
         result['size_remaining'] = user.get_size_remaining()
 
         return result
+

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -18,8 +18,6 @@ class CollsController(BaseController):
 
         self.allow_external = get_bool(os.environ.get('ALLOW_EXTERNAL', False))
 
-        self.dat_share = DatShare()
-
     def init_routes(self):
         @self.app.post('/api/v1/collections')
         def create_collection():
@@ -193,20 +191,20 @@ class CollsController(BaseController):
 
         # DAT
         @self.app.post('/api/v1/collection/<coll_name>/dat/share')
-        def dat_share(coll_name):
+        def dat_do_share(coll_name):
             user, collection = self.load_user_coll(coll_name=coll_name)
 
-            result = self.dat_share(user, collection, share=True)
+            result = DatShare.dat_share(collection, share=True, author=user.name)
             if 'error' in result:
                 self._raise_error(400, result['error'])
 
             return result
 
         @self.app.post('/api/v1/collection/<coll_name>/dat/unshare')
-        def dat_share(coll_name):
+        def dat_do_unshare(coll_name):
             user, collection = self.load_user_coll(coll_name=coll_name)
 
-            result = self.dat_share(user, collection, share=False)
+            result = DatShare.dat_share(collection, share=False)
             if 'error' in result:
                 self._raise_error(400, result['error'])
 

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -15,7 +15,7 @@ from pkg_resources import resource_filename
 from six.moves.urllib.parse import urlsplit, urljoin, unquote
 
 from pywb.rewrite.templateview import JinjaEnv
-from webrecorder.utils import load_wr_config, init_logging
+from webrecorder.utils import load_wr_config, init_logging, spawn_once
 
 from webrecorder.apiutils import CustomJSONEncoder
 from webrecorder.admincontroller import AdminController
@@ -49,7 +49,6 @@ from webrecorder.basecontroller import BaseController
 from wsgiprox.wsgiprox import WSGIProxMiddleware
 
 from webrecorder.standalone.assetsutils import default_build
-import gevent
 
 
 # ============================================================================
@@ -76,7 +75,7 @@ class MainController(BaseController):
             self.static_root = os.path.join(sys._MEIPASS, 'webrecorder', 'static/')
         else:
             self.static_root = resource_filename('webrecorder', 'static/')
-            gevent.spawn(default_build, force_build=False)
+            spawn_once(default_build, worker=1, force_build=False)
 
         bottle_app = Bottle()
         self.bottle_app = bottle_app

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -40,6 +40,8 @@ from webrecorder.session import Session, RedisSessionMiddleware
 
 from webrecorder.models.access import SessionAccessCache
 from webrecorder.models.usermanager import UserManager
+from webrecorder.models.datshare import DatShare
+
 from webrecorder.rec.storage import storagepaths
 
 from webrecorder.basecontroller import BaseController
@@ -106,6 +108,9 @@ class MainController(BaseController):
 
         # Init Browser Mgr
         browser_mgr = BrowserManager(config, browser_redis, user_manager)
+
+        # Init Dat Share
+        DatShare.dat_share = DatShare(self.redis)
 
         # Init Content Loader/Rewriter
         content_app = ContentController(app=bottle_app,

--- a/webrecorder/webrecorder/models/base.py
+++ b/webrecorder/webrecorder/models/base.py
@@ -189,6 +189,10 @@ class RedisUniqueComponent(object):
         except:
             return dt
 
+        # default date: fix for Windows on py3.6
+        if dt <= 0:
+            dt = 86400
+
         #return datetime.fromtimestamp(t).strftime('%Y-%m-%d %H:%M:%S.%f')
         dt = datetime.fromtimestamp(dt).isoformat()
         if no_T:

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -15,6 +15,7 @@ from webrecorder.utils import sanitize_title
 from webrecorder.models.base import RedisUnorderedList, RedisOrderedList, RedisUniqueComponent, RedisNamedMap
 from webrecorder.models.recording import Recording
 from webrecorder.models.pages import PagesMixin
+from webrecorder.models.datshare import DatShare
 from webrecorder.models.list_bookmarks import BookmarkList
 from webrecorder.rec.storage import get_storage as get_global_storage
 
@@ -40,6 +41,10 @@ class Collection(PagesMixin, RedisUniqueComponent):
     DEFAULT_STORE_TYPE = 'local'
 
     COLL_CDXJ_TTL = 1800
+
+    DAT_PROP = 'dat_key'
+    DAT_COMMITTED_AT = 'dat_committed_at'
+    DAT_COLLS = 's:dat_colls'
 
     def __init__(self, **kwargs):
         super(Collection, self).__init__(**kwargs)
@@ -307,6 +312,8 @@ class Collection(PagesMixin, RedisUniqueComponent):
         if not self.delete_object():
             errs['error'] = 'not_found'
 
+        self.dat_unshare(remove=True)
+
         return errs
 
     def get_storage(self):
@@ -360,6 +367,23 @@ class Collection(PagesMixin, RedisUniqueComponent):
 
     def set_external(self, external):
         self.set_bool_prop('external', external)
+
+    def dat_share(self, dat_key):
+        self.set_prop(self.DAT_PROP, dat_key)
+        self.set_prop(self.DAT_COMMITTED_AT, self._get_now())
+
+        self.redis.sadd(self.DAT_COLLS, self.my_id)
+
+    def dat_unshare(self, remove=False):
+        dat_key = self.get_prop(self.DAT_PROP)
+
+        if dat_key:
+            self.redis.srem(self.DAT_COLLS, self.my_id)
+            self.set_prop(self.DAT_PROP, '')
+
+            # TODO: better way to ensure dat removal?
+            if remove:
+                DatShare().remove_only(self)
 
     def sync_coll_index(self, exists=False, do_async=False):
         coll_cdxj_key = self.COLL_CDXJ_KEY.format(coll=self.my_id)

--- a/webrecorder/webrecorder/models/datshare.py
+++ b/webrecorder/webrecorder/models/datshare.py
@@ -1,12 +1,19 @@
 import os
 import requests
+import gevent
 
-from webrecorder.utils import get_bool
+from webrecorder.utils import get_bool, spawn_once
 
 
 # ============================================================================
 class DatShare(object):
-    def __init__(self):
+    DAT_PROP = 'dat_key'
+    DAT_COMMITTED_AT = 'dat_committed_at'
+    DAT_COLLS = 'h:dat_colls'
+
+    def __init__(self, redis):
+        self.redis = redis
+
         self.dat_enabled = get_bool(os.environ.get('ALLOW_DAT', True))
         self.dat_host = os.environ.get('DAT_SHARE_HOST', 'dat')
         self.dat_port = int(os.environ.get('DAT_SHARE_PORT', 3000))
@@ -14,7 +21,42 @@ class DatShare(object):
         self.dat_url = 'http://{dat_host}:{dat_port}'.format(dat_host=self.dat_host,
                                                              dat_port=self.dat_port)
 
-    def __call__(self, user, collection, share=True):
+        self.num_shared_dats = self.redis.hlen(self.DAT_COLLS)
+
+        if self.dat_enabled:
+            spawn_once(self.dat_check, worker=1)
+
+    def dat_check(self):
+        while True:
+            try:
+                res = requests.get(self.dat_url + '/numDats')
+                res.raise_for_status()
+                curr_dats = res.json()['num']
+            except:
+                print('Error reaching dat-share')
+                continue
+
+            if curr_dats != self.num_shared_dats:
+                print('Actual: {0} != Expected: {1}'.format(curr_dats, self.num_shared_dats))
+                self.readd_all()
+
+            gevent.sleep(30)
+
+    def readd_all(self):
+        dat_dirs = self.redis.hvals(self.DAT_COLLS)
+        res = None
+        try:
+            data = {'dirs': dat_dirs}
+            res = requests.post(self.dat_url + '/sync', json=data)
+            res.raise_for_status()
+        except Exception as e:
+            print(e)
+            print('Error bulkShare')
+            if res:
+                print(res.text)
+
+
+    def __call__(self, collection, share=True, author=None):
         collection.access.assert_can_admin_coll(collection)
 
         if not self.dat_enabled:
@@ -28,13 +70,14 @@ class DatShare(object):
         if share:
             cmd = '/share'
 
-            metadata = {'title': collection.get_prop('title'),
-                        'author': user.name,
-                       }
+            metadata = {'title': collection.get_prop('title')}
 
             desc = collection.get_prop('desc')
             if desc:
                 metadata['description'] = desc
+
+            if author:
+                metadata['author'] = author
 
             data['metadata'] = metadata
 
@@ -45,27 +88,29 @@ class DatShare(object):
             res = requests.post(self.dat_url + cmd, json=data)
             res.raise_for_status()
             dat_res = res.json()
+
             if share:
-                collection.dat_share(dat_res['dat'])
+                collection.set_prop(self.DAT_PROP, dat_res['dat'])
+                collection.set_prop(self.DAT_COMMITTED_AT, collection._get_now())
+
+                self.redis.hset(self.DAT_COLLS,
+                                collection.my_id,
+                                collection.get_dir_path())
+
             else:
-                collection.dat_unshare()
+                collection.set_prop(self.DAT_PROP, '')
+
+                self.redis.hdel(self.DAT_COLLS, collection.my_id)
+
+            self.num_shared_dats = self.redis.hlen(self.DAT_COLLS)
 
         except Exception as e:
             return {'error': str(e)}
 
         return dat_res
 
-    def remove_only(self, data):
-        if not self.dat_enabled:
-            return False
 
-        try:
-            data = {'collDir': collection.get_dir_path()}
-            res = requests.post(self.dat_url + '/unshare', json=data)
-        except Exception as e:
-            print(e)
-            return False
-
-        return True
+# ============================================================================
+dat_share = None
 
 

--- a/webrecorder/webrecorder/models/datshare.py
+++ b/webrecorder/webrecorder/models/datshare.py
@@ -1,0 +1,71 @@
+import os
+import requests
+
+from webrecorder.utils import get_bool
+
+
+# ============================================================================
+class DatShare(object):
+    def __init__(self):
+        self.dat_enabled = get_bool(os.environ.get('ALLOW_DAT', True))
+        self.dat_host = os.environ.get('DAT_SHARE_HOST', 'dat')
+        self.dat_port = int(os.environ.get('DAT_SHARE_PORT', 3000))
+
+        self.dat_url = 'http://{dat_host}:{dat_port}'.format(dat_host=self.dat_host,
+                                                             dat_port=self.dat_port)
+
+    def __call__(self, user, collection, share=True):
+        collection.access.assert_can_admin_coll(collection)
+
+        if not self.dat_enabled:
+            return {'error': 'not_supported'}
+
+        if collection.is_external():
+            return {'error': 'external_not_allowed'}
+
+        data = {'collDir': collection.get_dir_path()}
+
+        if share:
+            cmd = '/share'
+
+            metadata = {'title': collection.get_prop('title'),
+                        'author': user.name,
+                       }
+
+            desc = collection.get_prop('desc')
+            if desc:
+                metadata['description'] = desc
+
+            data['metadata'] = metadata
+
+        else:
+            cmd = '/unshare'
+
+        try:
+            res = requests.post(self.dat_url + cmd, json=data)
+            res.raise_for_status()
+            dat_res = res.json()
+            if share:
+                collection.dat_share(dat_res['dat'])
+            else:
+                collection.dat_unshare()
+
+        except Exception as e:
+            return {'error': str(e)}
+
+        return dat_res
+
+    def remove_only(self, data):
+        if not self.dat_enabled:
+            return False
+
+        try:
+            data = {'collDir': collection.get_dir_path()}
+            res = requests.post(self.dat_url + '/unshare', json=data)
+        except Exception as e:
+            print(e)
+            return False
+
+        return True
+
+

--- a/webrecorder/webrecorder/models/datshare.py
+++ b/webrecorder/webrecorder/models/datshare.py
@@ -32,6 +32,9 @@ class DatShare(object):
         if self.dat_enabled:
             spawn_once(self.dat_sync_check_loop, worker=1)
 
+    def close(self):
+        self.running = False
+
     def init_dat(self, collection):
         res = self.dat_share_api('/init', collection)
         return res['datKey']
@@ -135,7 +138,7 @@ class DatShare(object):
                 break
 
             print('Waiting for dat.json, metadata commit...')
-            time.sleep(10)
+            gevent.sleep(10)
 
         res = self.dat_share_api('/share', collection)
 
@@ -164,7 +167,7 @@ class DatShare(object):
         sleep_time = int(os.environ.get('DAT_SYNC_CHECK_TIME', '30'))
         print('Running Dat Sync Check every {0} seconds'.format(sleep_time))
 
-        while True:
+        while self.running:
             self.dat_sync()
             gevent.sleep(sleep_time)
 

--- a/webrecorder/webrecorder/models/recording.py
+++ b/webrecorder/webrecorder/models/recording.py
@@ -291,6 +291,7 @@ class Recording(RedisUniqueComponent):
         self._copy_prop(source, 'title')
         self._copy_prop(source, 'desc')
         self._copy_prop(source, 'rec_type')
+        self._copy_prop(source, 'recorded_at')
         #self._copy_prop(source, 'patch_rec')
 
         collection = self.get_owner()

--- a/webrecorder/webrecorder/rec/main.py
+++ b/webrecorder/webrecorder/rec/main.py
@@ -1,16 +1,7 @@
 from gevent import monkey; monkey.patch_all()
 
-from webrecorder.utils import load_wr_config, init_logging
+from webrecorder.utils import load_wr_config, init_logging, spawn_once
 from webrecorder.rec.webrecrecorder import WebRecRecorder
-
-import gevent
-
-try:
-    import uwsgi
-    from uwsgidecorators import postfork
-except:
-    postfork = None
-    pass
 
 
 # =============================================================================
@@ -21,13 +12,7 @@ def init():
 
     wr = WebRecRecorder(config)
 
-    if postfork:
-        @postfork
-        def listen_loop():
-            if uwsgi.mule_id() == 0:
-                wr.msg_ge = gevent.spawn(wr.msg_listen_loop)
-    else:
-        wr.msg_ge = gevent.spawn(wr.msg_listen_loop)
+    spawn_once(wr.msg_listen_loop)
 
     wr.init_app()
     wr.app.wr = wr

--- a/webrecorder/webrecorder/rec/storage/base.py
+++ b/webrecorder/webrecorder/rec/storage/base.py
@@ -10,7 +10,12 @@ class BaseStorage(object):
         return self.storage_root + collection.get_dir_path()
 
     def get_target_url(self, collection, obj_type, filename):
-        return self.get_collection_url(collection) + '/' + obj_type + '/' + filename
+        url = self.get_collection_url(collection) + '/'
+        if obj_type:
+            url += obj_type + '/'
+
+        url += filename
+        return url
 
     def init_collection(self, collection):
         return True

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -100,6 +100,23 @@ def today_str():
 
 
 # ============================================================================
+def spawn_once(*args, **kwargs):
+    try:
+        import uwsgi
+        from uwsgidecorators import postfork
+
+        worker_id = kwargs.pop('worker')
+        mule_id = kwargs.pop('mule', 0)
+
+        @postfork
+        def listen_loop():
+            if (mule_id is None or uwsgi.mule_id() == mule_id) and (worker_id is None or uwsgi.worker_id() == worker_id):
+                gevent.spawn(*args, **kwargs)
+    except:
+        gevent.spawn(*args, **kwargs)
+
+
+# ============================================================================
 @contextmanager
 def redis_pipeline(redis_obj):
     p = redis_obj.pipeline(transaction=False)

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -54,8 +54,8 @@ def init_props(config):
 
 
 # ============================================================================
-def get_new_id(max_len=None):
-    res = base64.b32encode(os.urandom(10)).decode('utf-8').lower()
+def get_new_id(max_len=None, size=10):
+    res = base64.b32encode(os.urandom(size)).decode('utf-8').lower()
     if max_len:
         res = res[:max_len]
     return res
@@ -101,12 +101,12 @@ def today_str():
 
 # ============================================================================
 def spawn_once(*args, **kwargs):
+    worker_id = kwargs.pop('worker', '')
+    mule_id = kwargs.pop('mule', 0)
+
     try:
         import uwsgi
         from uwsgidecorators import postfork
-
-        worker_id = kwargs.pop('worker')
-        mule_id = kwargs.pop('mule', 0)
 
         @postfork
         def listen_loop():


### PR DESCRIPTION
Adds experimental DAT support to Webrecorder.
Includes:
- Updating Docker Compose to launch an instance of https://github.com/webrecorder/dat-share which a standalone project used to actually swarm multiple collection dats.
- Collection Commit API `/api/v1/collection/<name>/commit` which will commit all active recordings to storage (close any active WARCs in that collection)
- DAT Share API `/api/v1/collection/<name>/dat/share`which initializes a dat in a collection on first use and adds it to a shared swarm via an api call `dat-share` container. Also writes out the `dat.json` and serializes metadata to `metadata.yaml` Returns the dat and discovery keys.
- Dat Unshare API: `/api/v1/collection/<name>/dat/unshare` which stops a dat from being swarmed by dat-share (but does not delete any existing dats).
- General support for serializing Webrecorder metadata, recordings/pages/lists into a yaml file.
- Some testing improvements: avoid starting gevent loops while testing, which should help with appveyor tests.