### PR TITLE
player/upload fixes: ensure 'public_index' is set correctly on regula…

### DIFF
--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -167,7 +167,7 @@ class Collection(PagesMixin, RedisUniqueComponent):
         else:
             return len(self.get_lists())
 
-    def init_new(self, slug, title, desc='', public=False):
+    def init_new(self, slug, title, desc='', public=False, public_index=False):
         coll = self._create_new_id()
 
         key = self.INFO_KEY.format(coll=coll)
@@ -176,7 +176,7 @@ class Collection(PagesMixin, RedisUniqueComponent):
                      'size': 0,
                      'desc': desc,
                      'public': self._from_bool(public),
-                     'public_index': False,
+                     'public_index': self._from_bool(public_index),
                     }
 
         self._init_new()


### PR DESCRIPTION
…r upload

player: ensure collection is made public, public_index is set and lists are also set as public when using player inplace importer
test_player_proxy: ensure collection fully inited, ensure public_index and public set on collection, run player on random port
test_upload: also run player on random port as part of upload tests with auto-generated warc, ensure collection and lists are public