### PR TITLE
collection: import from serialized metadata prototype:

### DIFF
--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -205,7 +205,8 @@ class CollsController(BaseController):
             user, collection = self.load_user_coll(coll_name=coll_name)
 
             try:
-                result = DatShare.dat_share.share(collection)
+                data = request.json or {}
+                result = DatShare.dat_share.share(collection, data.get('always_update', False))
             except Exception as e:
                 result = {'error': 'api_error', 'details': str(e)}
 

--- a/webrecorder/webrecorder/models/base.py
+++ b/webrecorder/webrecorder/models/base.py
@@ -59,6 +59,20 @@ class RedisUniqueComponent(object):
     def get_bool_prop(self, prop, default_val=False):
         return get_bool(self.get_prop(prop, default_val=False))
 
+    def set_date_prop(self, ts_prop, info, src_prop=None):
+        try:
+            src_prop = src_prop or ts_prop
+            value = info.get(src_prop)
+            try:
+                value = int(value)
+            except ValueError:
+                value = int(datetime.strptime(value, '%Y-%m-%dT%H:%M:%S').timestamp())
+
+            self.set_prop(ts_prop, value, update_ts=False)
+
+        except (ValueError, TypeError) as e:
+            pass
+
     def is_public(self):
         return self.get_bool_prop('public')
 
@@ -193,7 +207,6 @@ class RedisUniqueComponent(object):
         if dt <= 0:
             dt = 86400
 
-        #return datetime.fromtimestamp(t).strftime('%Y-%m-%d %H:%M:%S.%f')
         dt = datetime.fromtimestamp(dt).isoformat()
         if no_T:
             dt = dt.replace('T', ' ')

--- a/webrecorder/webrecorder/models/importer.py
+++ b/webrecorder/webrecorder/models/importer.py
@@ -181,14 +181,15 @@ class BaseImporter(ImportStatusChecker):
                 if diff > 0:
                     self._add_split_padding(diff, upload_key)
 
-                self.set_date_prop(info['recording'], info, 'created_at')
-                self.set_date_prop(info['recording'], info, 'recorded_at')
-                self.set_date_prop(info['recording'], info, 'updated_at')
+                recording = info['recording']
+                recording.set_date_prop('created_at', info)
+                recording.set_date_prop('recorded_at', info)
+                recording.set_date_prop('updated_at', info)
 
             self.import_lists(first_coll, page_id_map)
 
-            self.set_date_prop(first_coll, first_coll.data, 'created_at', '_created_at')
-            self.set_date_prop(first_coll, first_coll.data, 'updated_at', '_updated_at')
+            first_coll.set_date_prop('created_at', first_coll.data, '_created_at')
+            first_coll.set_date_prop('updated_at', first_coll.data, '_updated_at')
 
         except:
             traceback.print_exc()
@@ -455,16 +456,6 @@ class BaseImporter(ImportStatusChecker):
 
         # ignore if no json-metadata or doesn't contain type of colleciton or recording
         return warcinfo if valid else None
-
-    def set_date_prop(self, obj, info, ts_prop, src_prop=None):
-        try:
-            src_prop = src_prop or ts_prop
-            value = info.get(src_prop)
-            obj.set_prop(ts_prop, int(value), update_ts=False)
-
-        except (ValueError, TypeError):
-            pass
-
 
     def do_upload(self, upload_key, filename, stream, user, coll, rec, offset, length):
         raise NotImplemented()


### PR DESCRIPTION
- add collection import_serialized() which rebuilds collection from root dir and metadata produced by serialize()
- add player --coll-dir option to initialize collection from serialized metadata.yaml
- dat: metadata.yaml serialization writes pages per recording, not per collection (to match warc download serialization)
- dat share: add always_update=true option to force update even if no changes detected