### PR TITLE
dat api work: allow dat access only for beta-archivist users

### DIFF
--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -374,6 +374,12 @@ class Collection(PagesMixin, RedisUniqueComponent):
         data['public'] = self.is_public()
         data['public_index'] = self.get_bool_prop('public_index', False)
 
+        if DatShare.DAT_SHARE in data:
+            data[DatShare.DAT_SHARE] = self.get_bool_prop(DatShare.DAT_SHARE, False)
+
+        if DatShare.DAT_UPDATED_AT in data:
+            data[DatShare.DAT_UPDATED_AT] = self.to_iso_date(data[DatShare.DAT_UPDATED_AT])
+
         if include_pages:
             if is_owner or data['public_index']:
                 data['pages'] = self.list_pages()

--- a/webrecorder/webrecorder/models/datshare.py
+++ b/webrecorder/webrecorder/models/datshare.py
@@ -11,8 +11,9 @@ from tempfile import NamedTemporaryFile
 
 # ============================================================================
 class DatShare(object):
-    DAT_PROP = 'dat_key'
-    DAT_COMMITTED_AT = 'dat_committed_at'
+    DAT_KEY_PROP = 'dat_key'
+    DAT_SHARE = 'dat_share'
+    DAT_UPDATED_AT = 'dat_updated_at'
     DAT_COLLS = 'h:dat_colls'
 
     def __init__(self, redis):
@@ -115,8 +116,8 @@ class DatShare(object):
         if user.is_anon():
             return {'error': 'not_logged_in'}
 
-        dat_key = collection.get_prop(self.DAT_PROP)
-        dat_updated = collection.get_prop(self.DAT_COMMITTED_AT)
+        dat_key = collection.get_prop(self.DAT_KEY_PROP)
+        dat_updated = collection.get_prop(self.DAT_UPDATED_AT)
 
         already_shared = False
 
@@ -146,8 +147,8 @@ class DatShare(object):
 
         res = self.dat_share_api('/share', collection)
 
-        collection.set_prop(self.DAT_PROP, res['datKey'])
-        collection.set_prop(self.DAT_COMMITTED_AT, collection._get_now())
+        collection.set_prop(self.DAT_KEY_PROP, res['datKey'])
+        collection.set_prop(self.DAT_UPDATED_AT, collection._get_now())
 
         self._mark_share(collection)
 
@@ -161,8 +162,12 @@ class DatShare(object):
                         collection.my_id,
                         collection.get_dir_path())
 
+        collection.set_bool_prop(self.DAT_SHARE, True)
+
     def _mark_unshare(self, collection):
         self.redis.hdel(self.DAT_COLLS, collection.my_id)
+
+        collection.set_bool_prop(self.DAT_SHARE, False)
 
     def is_sharing(self, collection):
         return self.redis.hexists(self.DAT_COLLS, collection.my_id)


### PR DESCRIPTION
- rename dat_committed_at -> dat_updated_at
- add 'dat_share' boolean to indicate if dat sharing is enabled
- unshare toggles dat_share, does not delete dat  key
- serialize: convert dat_updated_at to date, dat_share to boolean