### PR TITLE
user api:

### DIFF
--- a/webrecorder/test/test_admin_api.py
+++ b/webrecorder/test/test_admin_api.py
@@ -75,7 +75,7 @@ class TestAdminAPI(FullStackTests):
         res = self.testapp.get('/api/v1/admin/users')
         assert [user['username'] for user in res.json['users']] == ['adminuser', 'test']
         assert [user['role'] for user in res.json['users']] == ['admin', 'archivist']
-        assert [user['name'] for user in res.json['users']] == ['Test Admin', 'Test User']
+        assert [user['full_name'] for user in res.json['users']] == ['Test Admin', 'Test User']
         assert [user['max_size'] for user in res.json['users']] == ['1000000000', '1000000000']
 
     def test_api_temp_users(self):
@@ -89,7 +89,7 @@ class TestAdminAPI(FullStackTests):
                   'username': 'test',
                   'password': 'TestTest',
                   'role': 'archivist2',
-                  'name': 'Another User'}
+                  'full_name': 'Another User'}
 
         res = self.testapp.post_json('/api/v1/admin/users', params=params)
 
@@ -104,7 +104,7 @@ class TestAdminAPI(FullStackTests):
                   'username': 'another',
                   'password': 'TestTest789',
                   'role': 'archivist',
-                  'name': 'Another User'}
+                  'full_name': 'Another User'}
 
         res = self.testapp.post_json('/api/v1/admin/users', params=params)
 
@@ -114,7 +114,7 @@ class TestAdminAPI(FullStackTests):
         res = self.testapp.get('/api/v1/admin/users')
         assert [user['username'] for user in res.json['users']] == ['adminuser', 'another', 'test']
         assert [user['role'] for user in res.json['users']] == ['admin', 'archivist', 'archivist']
-        assert [user['name'] for user in res.json['users']] == ['Test Admin', 'Another User', 'Test User']
+        assert [user['full_name'] for user in res.json['users']] == ['Test Admin', 'Another User', 'Test User']
         assert [user['max_size'] for user in res.json['users']] == ['1000000000', '7000000000', '1000000000']
 
     def test_update_user_error_invalid_role_and_size(self):
@@ -136,7 +136,7 @@ class TestAdminAPI(FullStackTests):
 
         assert res.json['user']['space_utilization'] == {'available': 200000000, 'total': 200000000, 'used': 0}
         assert res.json['user']['role'] == 'beta-archivist'
-        assert res.json['user']['name'] == 'Test User'
+        assert res.json['user']['full_name'] == 'Test User'
         assert res.json['user']['desc'] == 'Custom Desc'
 
     def test_api_stats_search(self):

--- a/webrecorder/test/test_api_user_login.py
+++ b/webrecorder/test/test_api_user_login.py
@@ -411,7 +411,7 @@ class TestApiUserLogin(FullStackTests):
 
     def test_update_user_desc(self):
         params = {'desc': 'New Description',
-                  'display_name': 'Some User',
+                  'full_name': 'Some User',
                   'display_url': 'http://someuser.example.com/'}
 
         res = self.testapp.post_json('/api/v1/user/someuser', params=params)
@@ -427,7 +427,7 @@ class TestApiUserLogin(FullStackTests):
 
         assert user['username'] == 'someuser'
         assert user['desc'] == 'New Description'
-        assert user['display_name'] == 'Some User'
+        assert user['full_name'] == 'Some User'
         assert user['display_url'] == 'http://someuser.example.com/'
 
         # collections not included

--- a/webrecorder/test/test_dat_api.py
+++ b/webrecorder/test/test_dat_api.py
@@ -58,7 +58,7 @@ class TestDatShare(FullStackTests):
                   'password': 'TestTest123'}
 
         res = self.testapp.post_json('/api/v1/auth/login', params=params)
-        assert res.json['username'] == 'test'
+        assert res.json['user']['username'] == 'test'
 
         res = self.testapp.get('/test/default-collection')
         res.charset = 'utf-8'

--- a/webrecorder/webrecorder/admincontroller.py
+++ b/webrecorder/webrecorder/admincontroller.py
@@ -528,7 +528,7 @@ class AdminController(BaseController):
                 role=data['role'],
                 passwd=data['password'],
                 passwd2=data['password'],
-                name=data.get('name', ''))
+                name=data.get('full_name', ''))
 
             # validate
             if errs:

--- a/webrecorder/webrecorder/models/user.py
+++ b/webrecorder/webrecorder/models/user.py
@@ -29,8 +29,8 @@ class User(RedisUniqueComponent):
     URL_SKIP_KEY = 'us:{user}:s:{url}'
     SKIP_KEY_SECS = 330
 
-    SERIALIZE_PROPS = ['desc', 'display_name', 'display_url']
-    SERIALIZE_FULL_PROPS = SERIALIZE_PROPS + ['name', 'role', 'last_login', 'updated_at', 'created_at', 'timespan', 'size', 'max_size']
+    SERIALIZE_PROPS = ['desc', 'display_url']
+    SERIALIZE_FULL_PROPS = SERIALIZE_PROPS + ['role', 'last_login', 'updated_at', 'created_at', 'timespan', 'size', 'max_size']
 
     @classmethod
     def init_props(cls, config):
@@ -220,7 +220,12 @@ class User(RedisUniqueComponent):
         all_data = super(User, self).serialize(include_duration=full)
 
         data = {'username': self.name}
+
         allowed_props = self.SERIALIZE_PROPS if not full else self.SERIALIZE_FULL_PROPS
+
+        full_name = all_data.get('name')
+        if full_name:
+            data['full_name'] = full_name
 
         for prop in allowed_props:
             if prop in all_data:

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -230,8 +230,8 @@ class UserController(BaseController):
             if 'desc' in data:
                 user['desc'] = data['desc']
 
-            if 'display_name' in data:
-                user['display_name'] = data['display_name'][:150]
+            if 'full_name' in data:
+                user['name'] = data['full_name'][:150]
 
             if 'display_url' in data:
                 user['display_url'] = data['display_url'][:500]


### PR DESCRIPTION
- use 'full_name' for user full name property for all apis (internally still stored in u:<user> 'name' property)
- update tests to check for 'full_name' instead of 'display_name'