### PR TITLE
pending size improvements: include pending size in status updates, im…

### DIFF
--- a/webrecorder/setup.py
+++ b/webrecorder/setup.py
@@ -111,7 +111,7 @@ setup(
         'mock',
         'responses',
         'httpbin==0.5.0',
-        'websocket'
+        'websocket-client'
        ],
     cmdclass={'test': PyTest,
               'install': Install},

--- a/webrecorder/setup.py
+++ b/webrecorder/setup.py
@@ -110,7 +110,8 @@ setup(
         'fakeredis',
         'mock',
         'responses',
-        'httpbin==0.5.0'
+        'httpbin==0.5.0',
+        'websocket'
        ],
     cmdclass={'test': PyTest,
               'install': Install},

--- a/webrecorder/test/test_anon_workflow.py
+++ b/webrecorder/test/test_anon_workflow.py
@@ -31,6 +31,8 @@ class TestTempContent(FullStackTests):
         'r:{rec}:open',
         'r:{rec}:info',
         'r:{rec}:wk',
+        'r:{rec}:_ps',
+        'r:{rec}:_pc',
         'c:{coll}:warc',
         'c:{coll}:p',
         'c:{coll}:info',

--- a/webrecorder/test/test_rate_limits.py
+++ b/webrecorder/test/test_rate_limits.py
@@ -17,6 +17,15 @@ class TestRateLimits(FullStackTests):
         os.environ['RATE_LIMIT_RESTRICTED_IPS'] = '255.255.255,10.0.0'
         super(TestRateLimits, cls).setup_class()
 
+    @classmethod
+    def teardown_class(cls):
+        super(TestRateLimits, cls).teardown_class()
+        del os.environ['RATE_LIMIT_MAX']
+        del os.environ['RATE_LIMIT_HOURS']
+        del os.environ['RATE_LIMIT_RESTRICTED_HOURS']
+        del os.environ['RATE_LIMIT_RESTRICTED_MAX']
+        del os.environ['RATE_LIMIT_RESTRICTED_IPS']
+
     def test_record_1(self):
         self.set_uuids('Recording', ['rec'])
         headers = {'X-Real-IP': '127.0.0.1'}

--- a/webrecorder/test/test_rec.py
+++ b/webrecorder/test/test_rec.py
@@ -72,6 +72,8 @@ class TestWebRecRecorder(FullStackTests):
             'r:REC:cdxj',
             'r:REC:info',
             'r:REC:open',
+            'r:REC:_ps',
+            'r:REC:_pc',
             'c:COLL:info',
             'c:COLL:warc',
             'u:USER:info'
@@ -94,13 +96,17 @@ class TestWebRecRecorder(FullStackTests):
 
         assert set(keys) == set([
             'r:REC:wk',
-            'r:REC2:wk',
             'r:REC:cdxj',
-            'r:REC2:cdxj',
             'r:REC:info',
             'r:REC:open',
+            'r:REC:_ps',
+            'r:REC:_pc',
+            'r:REC2:wk',
+            'r:REC2:cdxj',
             'r:REC2:info',
             'r:REC2:open',
+            'r:REC2:_ps',
+            'r:REC2:_pc',
             'c:COLL:info',
             'c:COLL:warc',
             'u:USER:info'

--- a/webrecorder/test/test_ws.py
+++ b/webrecorder/test/test_ws.py
@@ -1,0 +1,118 @@
+from .testutils import FullStackTests
+from webrecorder.fullstackrunner import FullStackRunner
+
+import os
+import gevent
+import websocket
+import requests
+import json
+
+
+# ============================================================================
+class TestWS(FullStackTests):
+    @classmethod
+    def setup_class(cls):
+        super(TestWS, cls).setup_class(init_anon=False)
+
+    @classmethod
+    def custom_init(cls, kwargs):
+        cls.runner = FullStackRunner(app_port=0, env_params=cls.runner_env_params)
+        cls.app_port = cls.runner.app_serv.port
+
+        cls.sesh = requests.session()
+
+        cls.anon_user = None
+
+    def get_url(self, url):
+        return self.sesh.get('http://localhost:{0}'.format(self.app_port) + url)
+
+    def post_json(self, url, json):
+        return self.sesh.post('http://localhost:{0}'.format(self.app_port) + url,
+                              json=json)
+
+    def test_user_cred(self):
+        res = self.get_url('/api/v1/auth/anon_user')
+        TestWS.anon_user = res.json()['anon_user']
+
+    def test_create_recording(self):
+        self.set_uuids('Recording', ['rec'])
+
+        #url = 'http://httpbin.org/drip'
+        res = self.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), json={'title': 'temp'})
+        assert res.json()['collection']
+
+        res = self.post_json('/api/v1/recordings?user={user}&coll=temp'.format(user=self.anon_user), json={})
+        assert res.json()['recording']
+        assert res.json()['recording']['id'] == 'rec'
+
+    def test_ws_record_init(self):
+        TestWS.ws = websocket.WebSocket()
+        TestWS.ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp&rec=rec&type=record'.format(self.app_port, user=self.anon_user))
+
+        msg = json.loads(self.ws.recv())
+
+        assert msg['size'] == 0
+        assert msg['pending_size'] == 0
+        assert msg['ws_type'] == 'status'
+
+    def test_ws_record_update(self):
+        res = self.get_url('/{user}/temp/rec/record/mp_/httpbin.org/get?foo=bar'.format(user=self.anon_user))
+
+        msg = json.loads(self.ws.recv())
+
+        assert msg['size'] > 0
+
+    def test_ws_record_update_pending(self):
+        def long_req():
+            res = self.get_url('/{user}/temp/rec/record/mp_/httpbin.org/drip'.format(user=self.anon_user))
+
+        gr = gevent.spawn(long_req)
+
+        def assert_pending():
+            msg = json.loads(self.ws.recv())
+
+            assert msg['pending_size'] > 0
+
+        self.sleep_try(0.2, 10.0, assert_pending)
+
+        def assert_not_pending():
+            msg = json.loads(self.ws.recv())
+
+            assert msg['pending_size'] == 0
+
+        self.sleep_try(0.2, 10.0, assert_not_pending)
+
+    def test_ws_replay(self):
+        replay_ws = websocket.WebSocket()
+        replay_ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp'.format(self.app_port, user=self.anon_user))
+
+        msg = json.loads(replay_ws.recv())
+
+        assert msg['size'] > 0
+        assert 'pending_size' not in msg
+        assert msg['ws_type'] == 'status'
+
+        replay_ws.close()
+
+    def test_extract_1(self):
+        self.set_uuids('Recording', ['ex', 'p-ex'])
+        res = self.get_url('/_new/temp/ex/extract:ia/1996/http://geocities.com/'.format(user=self.anon_user))
+
+        res = self.get_url('/{user}/temp/ex/extract:ia/1996mp_/http://geocities.com/'.format(user=self.anon_user))
+        #assert res.status_code == 302
+        #assert res.headers['Location'].endswith('/temp/extract-test-2/extract:ia/1996/http://geocities.com/')
+
+        res = self.get_url('/{user}/temp/ex/extract:ia/1996mp_/http://geocities.com/'.format(user=self.anon_user))
+        assert 'GeoCities' in res.text
+        assert 'wbinfo.timestamp = "19961226' in res.text
+
+    def test_ws_extract_update_with_stats(self):
+        ex_ws = websocket.WebSocket()
+        ex_ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp&rec=ex&type=extract&url=http://geocities.com/'.format(self.app_port, user=self.anon_user))
+
+        msg = json.loads(ex_ws.recv())
+
+        assert msg['size'] > 0
+        assert msg['pending_size'] == 0
+        assert msg['stats'] == {'ia': 1}
+        assert msg['ws_type'] == 'status'

--- a/webrecorder/test/test_ws.py
+++ b/webrecorder/test/test_ws.py
@@ -58,9 +58,12 @@ class TestWS(FullStackTests):
     def test_ws_record_update(self):
         res = self.get_url('/{user}/temp/rec/record/mp_/httpbin.org/get?foo=bar'.format(user=self.anon_user))
 
-        msg = json.loads(self.ws.recv())
+        def assert_size():
+            msg = json.loads(self.ws.recv())
 
-        assert msg['size'] > 0
+            assert msg['size'] > 0
+
+        self.sleep_try(0.2, 10.0, assert_size)
 
     def test_ws_record_update_pending(self):
         def long_req():
@@ -110,9 +113,17 @@ class TestWS(FullStackTests):
         ex_ws = websocket.WebSocket()
         ex_ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp&rec=ex&type=extract&url=http://geocities.com/'.format(self.app_port, user=self.anon_user))
 
-        msg = json.loads(ex_ws.recv())
+        def assert_size():
+            msg = json.loads(ex_ws.recv())
 
-        assert msg['size'] > 0
-        assert msg['pending_size'] == 0
-        assert msg['stats'] == {'ia': 1}
-        assert msg['ws_type'] == 'status'
+            assert msg['size'] > 0
+            assert msg['pending_size'] == 0
+            assert msg['stats'] == {'ia': 1}
+            assert msg['ws_type'] == 'status'
+
+
+        self.sleep_try(0.2, 10.0, assert_size)
+
+        ex_ws.close()
+        self.ws.close()
+

--- a/webrecorder/webrecorder/rec/webrecrecorder.py
+++ b/webrecorder/webrecorder/rec/webrecrecorder.py
@@ -20,6 +20,7 @@ from webrecorder.load.wamloader import WAMLoader
 import webrecorder.rec.storage.storagepaths as storagepaths
 from webrecorder.rec.storage.local import DirectLocalFileStorage
 
+from webrecorder.models.base import BaseAccess
 from webrecorder.models import Recording, Collection, Stats
 
 import redis
@@ -328,23 +329,13 @@ class SkipCheckingMultiFileWARCWriter(MultiFileWARCWriter):
         self.user_key = config['info_key_templ']['user']
 
     def create_write_buffer(self, params, name):
-        info_key = res_template(self.info_key, params)
-        open_key = res_template(self.open_rec_key, params)
-        params['_open_key'] = open_key
-        return TempWriteBuffer(self.redis, info_key, open_key, self.open_rec_ttl, name, params['url'])
+        recording = Recording(my_id=params['param.rec'],
+                              redis=self.redis,
+                              access=BaseAccess())
 
-    def is_rec_open(self, params):
-        open_key = params['_open_key']
-        #open_key = res_template(self.open_rec_key, params)
+        params['recording'] = recording
 
-        # update ttl for open recroding key, if it exists
-        # if not, abort opening new warc file here
-        if not self.redis.expire(open_key, self.open_rec_ttl):
-            # if expire fails, recording not open!
-            logging.debug('Writing skipped, recording not open for write: ' + open_key)
-            return False
-
-        return True
+        return TempWriteBuffer(recording, name, params['url'])
 
     def write_stream_to_file(self, params, stream):
         upload_id = params.get('param.upid')
@@ -361,7 +352,8 @@ class SkipCheckingMultiFileWARCWriter(MultiFileWARCWriter):
         return self._write_to_file(params, write_callback)
 
     def _is_write_resp(self, resp, params):
-        if not self.is_rec_open(params):
+        if not params['recording'].is_open():
+            logging.debug('Writing skipped, recording not open for write')
             return False
 
         user_key = res_template(self.user_key, params)
@@ -397,15 +389,12 @@ class SkipCheckingMultiFileWARCWriter(MultiFileWARCWriter):
 
 # ============================================================================
 class TempWriteBuffer(tempfile.SpooledTemporaryFile):
-    def __init__(self, redis, info_key, open_key, open_rec_ttl, class_name, url):
+    def __init__(self, recording, class_name, url):
         super(TempWriteBuffer, self).__init__(max_size=512*1024)
-        self.redis = redis
-        self.info_key = info_key
-        self.open_key = open_key
-        self.open_rec_ttl = open_rec_ttl
+        self.recording = recording
         self.class_name = class_name
-        if self.redis.expire(self.open_key, self.open_rec_ttl):
-            self.redis.hincrby(self.info_key, 'pending_count', 1)
+
+        self.recording.inc_pending_count()
 
         self._wsize = 0
 
@@ -413,8 +402,8 @@ class TempWriteBuffer(tempfile.SpooledTemporaryFile):
         super(TempWriteBuffer, self).write(buff)
         length = len(buff)
         self._wsize += length
-        if self.redis.expire(self.open_key, self.open_rec_ttl):
-            self.redis.hincrby(self.info_key, 'pending_size', length)
+
+        self.recording.inc_pending_size(length)
 
     def close(self):
         try:
@@ -422,8 +411,6 @@ class TempWriteBuffer(tempfile.SpooledTemporaryFile):
         except:
             traceback.print_exc()
 
-        if self.redis.exists(self.open_key):
-            self.redis.hincrby(self.info_key, 'pending_size', -self._wsize)
-            self.redis.hincrby(self.info_key, 'pending_count', -1)
+        self.recording.dec_pending_count_and_size(self._wsize)
 
 

--- a/webrecorder/webrecorder/rec/webrecrecorder.py
+++ b/webrecorder/webrecorder/rec/webrecrecorder.py
@@ -329,7 +329,8 @@ class SkipCheckingMultiFileWARCWriter(MultiFileWARCWriter):
         self.user_key = config['info_key_templ']['user']
 
     def create_write_buffer(self, params, name):
-        recording = Recording(my_id=params['param.rec'],
+        rec_id = params.get('param.recorder.rec') or params.get('param.rec')
+        recording = Recording(my_id=rec_id,
                               redis=self.redis,
                               access=BaseAccess())
 

--- a/webrecorder/webrecorder/websockcontroller.py
+++ b/webrecorder/webrecorder/websockcontroller.py
@@ -272,6 +272,9 @@ class BaseWebSockHandler(object):
             result = {'ws_type': 'status'}
             result['size'] = size
 
+            if self.recording:
+                result['pending_size'] = self.recording.get_pending_size()
+
             #result['numPages'] = obj.count_pages()
 
             if self.stats_urls:


### PR DESCRIPTION
…proved handling

- store pending_size and pending_count in expirable keys r:{id}:ps and r:{id}:pc respectively
- pending size/count ttl set to 90 secs, updated on every increment, to avoid any issues with stale pending size/count data
- pending size/count incremented only if recording is open
- pending size/count decremented if recording exists, even if not open
- webrecrecorder: using Recording object for pending size/count operations, remove redundant is_open logic
- websocketcontroller: set 'pending_size' to current pending size count for current recording, if any