### PR TITLE
API endpoint improvements, custom error page support

### DIFF
--- a/webrecorder/test/test_create_new_api.py
+++ b/webrecorder/test/test_create_new_api.py
@@ -23,7 +23,7 @@ class TestCreateNewAPISeparateDomains(FullStackTests):
         os.environ['APP_HOST'] = ''
 
     def test_empty_temp_user(self):
-        res = self.testapp.get('/api/v1/auth/curr_user', headers={'Host': 'app-host'})
+        res = self.testapp.get('/api/v1/auth/curr_user?persist=true', headers={'Host': 'app-host'})
         assert res.json['user']['username']
         username = res.json['user']['username']
 
@@ -31,7 +31,7 @@ class TestCreateNewAPISeparateDomains(FullStackTests):
         assert res.headers['Location'] == 'http://app-host/api/v1/user/' + username
 
     def test_init_anon(self):
-        res = self.testapp.get('/api/v1/auth/curr_user', headers={'Host': 'app-host'})
+        res = self.testapp.get('/api/v1/auth/curr_user?persist=true', headers={'Host': 'app-host'})
         TestCreateNewAPISeparateDomains.anon_user = res.json['user']['username']
 
         assert res.json['user']['username'] == self.anon_user

--- a/webrecorder/test/test_create_new_api.py
+++ b/webrecorder/test/test_create_new_api.py
@@ -23,7 +23,7 @@ class TestCreateNewAPISeparateDomains(FullStackTests):
         os.environ['APP_HOST'] = ''
 
     def test_empty_temp_user(self):
-        res = self.testapp.get('/api/v1/auth/curr_user?persist=true', headers={'Host': 'app-host'})
+        res = self.testapp.post('/api/v1/auth/anon_user', headers={'Host': 'app-host'})
         assert res.json['user']['username']
         username = res.json['user']['username']
 
@@ -31,7 +31,7 @@ class TestCreateNewAPISeparateDomains(FullStackTests):
         assert res.headers['Location'] == 'http://app-host/api/v1/user/' + username
 
     def test_init_anon(self):
-        res = self.testapp.get('/api/v1/auth/curr_user?persist=true', headers={'Host': 'app-host'})
+        res = self.testapp.post('/api/v1/auth/anon_user', headers={'Host': 'app-host'})
         TestCreateNewAPISeparateDomains.anon_user = res.json['user']['username']
 
         assert res.json['user']['username'] == self.anon_user

--- a/webrecorder/test/test_external.py
+++ b/webrecorder/test/test_external.py
@@ -1,26 +1,45 @@
 from .testutils import FullStackTests
 
+from urllib.parse import parse_qsl
+
 import os
 
 
 # ============================================================================
 class TestExternalColl(FullStackTests):
+    runner_env_params = {'TEMP_SLEEP_CHECK': '1',
+                         'APP_HOST': 'app-host',
+                         'CONTENT_HOST': 'content-host'}
+    anon_user = None
+
+
     @classmethod
     def setup_class(cls):
         os.environ['ALLOW_EXTERNAL'] = '1'
-        super(TestExternalColl, cls).setup_class()
+        os.environ['CONTENT_ERROR_REDIRECT'] = 'http://external.example.com/error'
+        os.environ['CONTENT_HOST'] = 'content-host'
+        os.environ['APP_HOST'] = 'app-host'
+        super(TestExternalColl, cls).setup_class(init_anon=False)
 
     @classmethod
     def teardown_class(cls):
         super(TestExternalColl, cls).teardown_class()
         os.environ.pop('ALLOW_EXTERNAL', '')
+        os.environ.pop('CONTENT_ERROR_REDIRECT', '')
+        os.environ.pop('CONTENT_HOST', '')
+        os.environ.pop('APP_HOST', '')
 
     def test_external_init(self):
         params = {'external': True,
                   'title': 'external'
                  }
 
-        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user), params=params)
+        res = self.testapp.get('/api/v1/auth/curr_user?persist=true', headers={'Host': 'app-host'})
+        TestExternalColl.anon_user = res.json['user']['username']
+
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user),
+                                     headers={'Host': 'app-host'},
+                                     params=params)
 
         assert res.json['collection']['slug'] == 'external'
 
@@ -29,7 +48,9 @@ class TestExternalColl(FullStackTests):
 com,example)/ 20180306181354 http://example.com/ text/html 200 A6DESOVDZ3WLYF57CS5E4RIC4ARPWRK7 - - 1214 773 test.warc.gz
 com,example)/fake 20180306181354 http://example.com/fake text/html 200 A6DESOVDZ3WLYF57CS5E4RIC4ARPWRK7 - - 1214 773 test.warc.gz
 """
-        res = self.testapp.put('/api/v1/collection/external/cdx?user={user}'.format(user=self.anon_user), params=cdx)
+        res = self.testapp.put('/api/v1/collection/external/cdx?user={user}'.format(user=self.anon_user),
+                               params=cdx,
+                               headers={'Host': 'app-host'})
 
         assert res.json['success'] == 2
 
@@ -37,12 +58,49 @@ com,example)/fake 20180306181354 http://example.com/fake text/html 200 A6DESOVDZ
         warc_path = 'file://' + os.path.join(self.get_curr_dir(), 'warcs', 'test_3_15_upload.warc.gz')
 
         res = self.testapp.put_json('/api/v1/collection/external/warc?user={user}'.format(user=self.anon_user),
-                                    params={'warcs': {'test.warc.gz': warc_path}})
+                                    params={'warcs': {'test.warc.gz': warc_path}},
+                                    headers={'Host': 'app-host'})
 
         assert res.json['success'] == 1
 
     def test_replay(self):
-        res = self.testapp.get('/{user}/external/mp_/http://example.com/'.format(user=self.anon_user))
+        res = self.testapp.get('/{user}/external/mp_/http://example.com/'.format(user=self.anon_user),
+                               headers={'Host': 'content-host'})
+
+        res = res.follow(headers={'Host': 'app-host'})
+        res = res.follow(headers={'Host': 'content-host'})
+        res = res.follow(headers={'Host': 'content-host'})
 
         assert 'Example Domain' in res.text
+
+    def test_error_redirect_content_not_found(self):
+        res = self.testapp.get('/{user}/external/mp_/http://example.com/not_found'.format(user=self.anon_user),
+                               status=307,
+                               headers={'Host': 'content-host'})
+
+        assert res.headers['Location'].startswith('http://external.example.com/error?')
+        args = dict(parse_qsl(res.headers['Location'].split('?', 1)[1]))
+        assert args == {'url': 'http://example.com/not_found',
+                        'user': self.anon_user,
+                        'type': 'replay-coll',
+                        'status': '404',
+                        'coll': 'external',
+                        'rec': '*',
+                        'error': '{"message": "No Resource Found"}',
+                        'app_host': 'app-host',
+                       }
+
+    def test_error_redirect_other(self):
+        res = self.testapp.get('/{user}/external2/mp_/http://example.com/not_found'.format(user=self.anon_user),
+                               status=303,
+                               headers={'Host': 'content-host'})
+
+        assert res.headers['Location'].startswith('http://external.example.com/error?')
+        args = dict(parse_qsl(res.headers['Location'].split('?', 1)[1]))
+        assert args == {
+                        'status': '404',
+                        'error': 'no_such_collection',
+                       }
+
+
 

--- a/webrecorder/test/test_external.py
+++ b/webrecorder/test/test_external.py
@@ -34,7 +34,7 @@ class TestExternalColl(FullStackTests):
                   'title': 'external'
                  }
 
-        res = self.testapp.get('/api/v1/auth/curr_user?persist=true', headers={'Host': 'app-host'})
+        res = self.testapp.post('/api/v1/auth/anon_user', headers={'Host': 'app-host'})
         TestExternalColl.anon_user = res.json['user']['username']
 
         res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user),

--- a/webrecorder/test/test_player_proxy.py
+++ b/webrecorder/test/test_player_proxy.py
@@ -8,6 +8,7 @@ import os
 import requests
 import gzip
 import json
+import websocket
 
 from tempfile import NamedTemporaryFile
 
@@ -28,7 +29,8 @@ class BaseTestPlayer(BaseTestClass):
         cls.warc_path = cls.create_temp_warc()
 
         cls.player = webrecorder_player(cls.get_player_cmd(), embed=True)
-        cls.app_host = 'http://localhost:' + str(cls.player.app_serv.port)
+        cls.app_port = cls.player.app_serv.port
+        cls.app_host = 'http://localhost:' + str(cls.app_port)
         cls.proxies = {'http': cls.app_host, 'https': cls.app_host}
 
     @classmethod
@@ -106,7 +108,6 @@ class TestPlayer(BaseTestPlayer):
     def test_coll_is_public(self):
         res = self.session.get(self.app_host + '/api/v1/collection/collection?user=local')
         collection = res.json()['collection']
-        print(collection)
         assert collection['public'] == True
         assert collection['public_index'] == True
 
@@ -179,6 +180,11 @@ class TestPlayer(BaseTestPlayer):
         assert res.text == 'Example Domain'
         assert res.url == 'http://example.com/'
         assert res.headers['Memento-Datetime'] == 'Wed, 01 Jan 2014 00:00:00 GMT'
+
+    def test_ws_init(self):
+        ws = websocket.WebSocket()
+        ws.connect('ws://localhost:{0}/_client_ws_cont'.format(self.app_port))
+        ws.close()
 
 
 # ============================================================================

--- a/webrecorder/test/test_ws.py
+++ b/webrecorder/test/test_ws.py
@@ -31,7 +31,7 @@ class TestWS(FullStackTests):
                               json=json)
 
     def test_user_cred(self):
-        res = self.get_url('/api/v1/auth/curr_user')
+        res = self.get_url('/api/v1/auth/curr_user?persist=true')
         TestWS.anon_user = res.json()['user']['username']
 
     def test_create_recording(self):

--- a/webrecorder/test/test_ws.py
+++ b/webrecorder/test/test_ws.py
@@ -26,12 +26,12 @@ class TestWS(FullStackTests):
     def get_url(self, url):
         return self.sesh.get('http://localhost:{0}'.format(self.app_port) + url)
 
-    def post_json(self, url, json):
+    def post_json(self, url, json=None):
         return self.sesh.post('http://localhost:{0}'.format(self.app_port) + url,
                               json=json)
 
     def test_user_cred(self):
-        res = self.get_url('/api/v1/auth/curr_user?persist=true')
+        res = self.post_json('/api/v1/auth/anon_user')
         TestWS.anon_user = res.json()['user']['username']
 
     def test_create_recording(self):

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -98,7 +98,7 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
         cls.testapp = webtest.TestApp(cls.maincont.app)
 
         if init_anon:
-            res = cls.testapp.get('/api/v1/auth/curr_user?persist=true')
+            res = cls.testapp.post('/api/v1/auth/anon_user')
             cls.anon_user = res.json['user']['username']
         else:
             cls.anon_user = None

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -98,7 +98,7 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
         cls.testapp = webtest.TestApp(cls.maincont.app)
 
         if init_anon:
-            res = cls.testapp.get('/api/v1/auth/curr_user')
+            res = cls.testapp.get('/api/v1/auth/curr_user?persist=true')
             cls.anon_user = res.json['user']['username']
         else:
             cls.anon_user = None

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -749,7 +749,7 @@ class ContentController(BaseController, RewriterApp):
                 return error
 
             if self.content_error_redirect:
-                return redirect(self.content_error_redirect + '?' + urlencode(err_context))
+                return redirect(self.content_error_redirect + '?' + urlencode(err_context), code=307)
             else:
                 return handle_error(err_context)
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -2,7 +2,7 @@ import re
 import os
 import json
 
-from six.moves.urllib.parse import quote, unquote
+from six.moves.urllib.parse import quote, unquote, urlencode
 
 from bottle import Bottle, request, HTTPError, response, HTTPResponse, redirect
 
@@ -77,7 +77,7 @@ class ContentController(BaseController, RewriterApp):
             csp += self.app_host + '/_set_session'
 
         if self.content_error_redirect:
-            csp += ' ' + self.content_error_redirect.split('?', 1)[0]
+            csp += ' ' + self.content_error_redirect
 
         csp += "; form-action 'self'"
         return csp
@@ -749,8 +749,7 @@ class ContentController(BaseController, RewriterApp):
                 return error
 
             if self.content_error_redirect:
-                return redirect(self.content_error_redirect.format_map(err_context))
-
+                return redirect(self.content_error_redirect + '?' + urlencode(err_context))
             else:
                 return handle_error(err_context)
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -379,8 +379,8 @@ class ContentController(BaseController, RewriterApp):
             sesh = self.get_session()
 
             if self.is_content_request():
-                id = request.query.getunicode('id')
-                sesh.set_id(id)
+                cookie = request.query.getunicode('cookie')
+                sesh.set_id_from_cookie(cookie)
                 return self.redirect(request.query.getunicode('path'))
 
             else:
@@ -388,7 +388,9 @@ class ContentController(BaseController, RewriterApp):
                 self.set_options_headers(self.content_host, self.app_host)
                 response.headers['Cache-Control'] = 'no-cache'
 
-                redirect(url + '/_set_session?' + request.environ['QUERY_STRING'] + '&id=' + quote(sesh.get_id()))
+                cookie = quote(request.environ.get('webrec.sesh_cookie', ''))
+                url += '/_set_session?{0}&cookie={1}'.format(request.environ['QUERY_STRING'], cookie)
+                redirect(url)
 
         # OPTIONS
         @self.app.route('/_set_session', method='OPTIONS')
@@ -743,7 +745,7 @@ class ContentController(BaseController, RewriterApp):
 
             @self.jinja2_view('content_error.html')
             def handle_error(error):
-                response.status = status_code
+                response.status = ue.status_code
                 return error
 
             if self.content_error_redirect:

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -1,4 +1,4 @@
-from bottle import debug, request, response, static_file
+from bottle import debug, request, response, static_file, redirect
 
 import logging
 import json
@@ -12,7 +12,7 @@ import os
 from jinja2 import contextfunction
 from pkg_resources import resource_filename
 
-from six.moves.urllib.parse import urlsplit, urljoin, unquote
+from six.moves.urllib.parse import urlsplit, urljoin, unquote, urlencode
 
 from pywb.rewrite.templateview import JinjaEnv
 from webrecorder.utils import load_wr_config, init_logging, spawn_once
@@ -96,6 +96,8 @@ class MainController(BaseController):
         browser_redis = redis.StrictRedis.from_url(os.environ['REDIS_BROWSER_URL'], decode_responses=True)
 
         session_redis = redis.StrictRedis.from_url(os.environ['REDIS_SESSION_URL'])
+
+        self.content_error_redirect = os.environ.get('CONTENT_ERROR_REDIRECT')
 
         # Init Jinja
         jinja_env = self.init_jinja_env(config)
@@ -410,7 +412,18 @@ class MainController(BaseController):
 
             # return html error view for any content errors
             if self.is_content_request():
-                return error_view(out)
+                if self.content_error_redirect:
+                    err_context = {'status': out.status_code,
+                                   'error': out.body
+                                  }
+
+                    response.status = 303
+                    redirect_url = self.content_error_redirect + '?' + urlencode(err_context)
+                    response.set_header('Location', redirect_url)
+                    return
+
+                else:
+                    return error_view(out)
 
             if isinstance(out.exception, dict):
                 return json_error(out.exception)

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -236,6 +236,8 @@ class RedisSessionMiddleware(CookieGuard):
         if not sesh_cookie.startswith(self.sesh_key + '='):
             return
 
+        sesh_cookie = sesh_cookie[len(self.sesh_key) + 1:]
+
         environ['webrec.sesh_cookie'] = sesh_cookie
 
         result = self.signed_cookie_to_id(sesh_cookie)
@@ -442,8 +444,6 @@ class RedisSessionMiddleware(CookieGuard):
             pi.delete(list_key)
 
     def signed_cookie_to_id(self, sesh_cookie):
-        sesh_cookie = sesh_cookie[len(self.sesh_key) + 1:]
-
         serial = URLSafeTimedSerializer(self.secret_key)
 
         try:

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -19,11 +19,12 @@ class Session(object):
     TEMP_KEY = 't:{0}'
     temp_prefix = ''
 
-    def __init__(self, cork, environ, redis, key, sesh, ttl, is_restricted):
+    def __init__(self, cork, environ, redis, key, sesh, ttl, is_restricted, sesh_manager):
         self.environ = environ
         self._sesh = sesh
         self.redis = redis
         self.key = key
+        self.sesh_manager = sesh_manager
 
         self.curr_role = None
 
@@ -80,6 +81,14 @@ class Session(object):
 
     def get_csrf(self):
         return self._sesh.get('csrf', '')
+
+    def set_id_from_cookie(self, cookie):
+        result = self.sesh_manager.signed_cookie_to_id(cookie)
+        if not result:
+            return
+
+        sesh_id, is_restricted = result
+        self.set_id(sesh_id)
 
     def set_id(self, id):
         self._sesh['id'] = id
@@ -217,33 +226,47 @@ class RedisSessionMiddleware(CookieGuard):
 
         self.access_cls = access_cls
 
+    def _load_session(self, environ):
+        sesh_cookie = self.split_cookie(environ)
+
+        if not sesh_cookie:
+            return
+
+        sesh_cookie = sesh_cookie.strip()
+        if not sesh_cookie.startswith(self.sesh_key + '='):
+            return
+
+        environ['webrec.sesh_cookie'] = sesh_cookie
+
+        result = self.signed_cookie_to_id(sesh_cookie)
+
+        if not result:
+            return
+
+        sesh_id, is_restricted = result
+        redis_key = self.key_template.format(sesh_id)
+
+        result = self.redis.get(redis_key)
+        if not result:
+            return
+
+        data = pickle.loads(base64.b64decode(result))
+        ttl = self.redis.ttl(redis_key)
+
+        return sesh_id, redis_key, data, ttl, is_restricted
+
     def init_session(self, environ):
+        sesh_id = None
+        redis_key = None
         data = None
         ttl = -2
         is_restricted = False
-        force_save = False
 
         if 'wsgiprox.proxy_host' not in environ:
             try:
-                sesh_cookie = self.split_cookie(environ)
-
-                result = self.signed_cookie_to_id(sesh_cookie)
-
+                result = self._load_session(environ)
                 if result:
-                    sesh_id, is_restricted = result
-                    redis_key = self.key_template.format(sesh_id)
-
-                    result = self.redis.get(redis_key)
-                    if result:
-                        data = pickle.loads(base64.b64decode(result))
-                        ttl = self.redis.ttl(redis_key)
-
-                        # no csrf for existing session?
-                        # add and save
-                        if not data.get('csrf'):
-                            data['csrf'] = self.make_id()
-                            force_save = True
-
+                    sesh_id, redis_key, data, ttl, is_restricted = result
             except Exception as e:
                 import traceback
                 traceback.print_exc()
@@ -267,10 +290,11 @@ class RedisSessionMiddleware(CookieGuard):
                           redis_key,
                           data,
                           ttl,
-                          is_restricted)
+                          is_restricted,
+                          self)
 
-        if force_save:
-            session.save()
+        #if force_save:
+        #    session.save()
 
         if session.curr_role == 'anon':
             session.template_params['anon_ttl'] = ttl
@@ -418,13 +442,6 @@ class RedisSessionMiddleware(CookieGuard):
             pi.delete(list_key)
 
     def signed_cookie_to_id(self, sesh_cookie):
-        if not sesh_cookie:
-            return None
-
-        sesh_cookie = sesh_cookie.strip()
-        if not sesh_cookie.startswith(self.sesh_key + '='):
-            return None
-
         sesh_cookie = sesh_cookie[len(self.sesh_key) + 1:]
 
         serial = URLSafeTimedSerializer(self.secret_key)

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -26,9 +26,14 @@ class UserController(BaseController):
         if username:
             user = self.get_user(user=username)
         else:
-            user = self.access.init_session_user(persist=get_bool(request.query.get('persist', False)))
+            user = self.access.session_user
 
         return {'user': user.serialize(include_colls=include_colls)}
+
+    def new_auth(self):
+        user = self.access.init_session_user(persist=True)
+
+        return {'user': user.serialize()}
 
     def get_user_or_raise(self, username=None, status=403, msg='unauthorized'):
         # ensure correct host
@@ -69,6 +74,11 @@ class UserController(BaseController):
         @self.app.get('/api/v1/auth/curr_user')
         def load_user():
             return self.load_user()
+
+        # AUTH NEW SESSION
+        @self.app.post('/api/v1/auth/anon_user')
+        def new_auth():
+            return self.new_auth()
 
         # REGISTRATION
         @self.app.post('/api/v1/auth/register')

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -26,7 +26,7 @@ class UserController(BaseController):
         if username:
             user = self.get_user(user=username)
         else:
-            user = self.access.init_session_user(persist=True)
+            user = self.access.init_session_user(persist=get_bool(request.query.get('persist', False)))
 
         return {'user': user.serialize(include_colls=include_colls)}
 


### PR DESCRIPTION
Various API usage improvements:
* API endpoint for creating new temp user session`/api/v1/auth/anon_user` readded, curr_user only returns user, does not initialize new session.

* Support for redirecting to custom error page in content view if `CONTENT_ERROR_REDIRECT` is set. Redirect happens for both replay not found and any generic error.

* Cookie handoff improvement, `__set_session` now accepts the `cookie=` param instead of internal `id=` param for better use with external services that are handing off the cookie.

* Test updates for new api, custom error page, and extra test for WS init in player proxy.