### PR TITLE
Temp user session fix

### DIFF
--- a/frontend/src/containers/App/App.js
+++ b/frontend/src/containers/App/App.js
@@ -11,7 +11,7 @@ import { asyncConnect } from 'redux-connect';
 import { DragDropContext } from 'react-dnd';
 
 import { isLoaded as isAuthLoaded,
-         load as loadAuth } from 'redux/modules/auth';
+         load as loadAuth, loadAnon } from 'redux/modules/auth';
 
 import { UserManagement } from 'containers';
 
@@ -295,7 +295,13 @@ const initalData = [
       const state = getState();
 
       if (!isAuthLoaded(state)) {
-        return dispatch(loadAuth());
+        return dispatch(loadAuth()).then(
+          (auth) => {
+            if (auth.user.anon) {
+              dispatch(loadAnon());
+            }
+          }
+        );
       }
 
       return undefined;

--- a/frontend/src/redux/modules/auth.js
+++ b/frontend/src/redux/modules/auth.js
@@ -9,6 +9,10 @@ const LOAD = 'wr/auth/LOAD';
 const LOAD_SUCCESS = 'wr/auth/LOAD_SUCCESS';
 const LOAD_FAIL = 'wr/auth/LOAD_FAIL';
 
+const LOAD_ANON = 'wr/auth/LOAD_ANON';
+const LOAD_ANON_SUCCESS = 'wr/auth/LOAD_ANON_SUCCESS';
+const LOAD_ANON_FAIL = 'wr/auth/LOAD_ANON_FAIL';
+
 const LOGIN = 'wr/auth/LOGIN';
 export const LOGIN_SUCCESS = 'wr/auth/LOGIN_SUCCESS';
 const LOGIN_FAIL = 'wr/auth/LOGIN_FAIL';
@@ -209,6 +213,14 @@ export function load(include_colls = true) {
 }
 
 
+export function loadAnon() {
+  return {
+    types: [LOAD_ANON, LOAD_ANON_SUCCESS, LOAD_ANON_FAIL],
+    promise: client => client.post(`${apiPath}/auth/anon_user`)
+  };
+}
+
+
 export function loadCollections(user) {
   return {
     types: [USER_LOAD_COLLECTIONS, USER_LOAD_COLLECTIONS_SUCCESS, USER_LOAD_COLLECTIONS_FAIL],
@@ -227,7 +239,7 @@ export function loadRoles() {
   return {
     types: [USER_ROLES, USER_ROLES_SUCCESS, USER_ROLES_FAIL],
     promise: client => client.get(`${apiPath}/admin/user_roles`)
-  }
+  };
 }
 
 

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -83,6 +83,9 @@ class Session(object):
         return self._sesh.get('csrf', '')
 
     def set_id_from_cookie(self, cookie):
+        if not cookie:
+            return
+
         result = self.sesh_manager.signed_cookie_to_id(cookie)
         if not result:
             return


### PR DESCRIPTION
- If request isn't a logged in or active temp user, call `/api/v1/auth/anon_user` to add a cookie explicitly.
- Add cookie check in session.py