### PR TITLE
Ensure server-side render cookie has "Secure" flag

### DIFF
--- a/frontend/src/helpers/ApiClient.js
+++ b/frontend/src/helpers/ApiClient.js
@@ -62,8 +62,12 @@ export default class ApiClient {
 
           if (__SERVER__) {
             // if api sets session cookie, ensure its passed back to browser
-            const cookie = response.get('Set-Cookie');
+            var cookie = response.get('Set-Cookie');
             if (cookie) {
+              if (process.env.SCHEME == "https") {
+                cookie += "; Secure";
+              }
+
               res.set('Set-Cookie', cookie);
             }
           }


### PR DESCRIPTION
When server-side session cookie is passed from api to browser, ensure the `Secure` flag is also added in running via https to be consistent with cookies set directly via api.