### PR TITLE
Detect and reset content cookie if it out of sync with app cookie

### DIFF
--- a/webrecorder/test/test_app_content_domain.py
+++ b/webrecorder/test/test_app_content_domain.py
@@ -282,4 +282,97 @@ class TestAppContentDomain(FullStackTests):
         assert res.headers['Access-Control-Allow-Origin'] == 'http://app-host'
         assert res.headers['Access-Control-Allow-Credentials'] == 'true'
 
+    def test_login_and_replay(self):
+        res = self.testapp.post_json('/api/v1/auth/login',
+                                     params={'username': 'test', 'password': 'TestTest123'},
+                                     headers={'Host': 'app-host'})
+
+
+        assert res.json['user']['username'] == 'test'
+
+        res = self.app_get('/test/default-collection/http://httpbin.org/get?food=bar', status=200)
+
+        res = self.content_get('/test/default-collection/mp_/http://httpbin.org/get?food=bar', status=302)
+        assert 'http://app-host/_set_session' in res.headers['Location']
+
+        res = self.app_get(res.headers['Location'], status=302)
+        assert 'http://content-host/_set_session' in res.headers['Location']
+
+        res = self.content_get(res.headers['Location'])
+        content_host_str = 'http://content-host/test/default-collection/mp_/http://httpbin.org/get?food=bar'
+        assert res.status_code == 302
+        assert self.testapp.cookies['__test_sesh'] in res.headers['Set-Cookie']
+
+        # no max-age for logged in
+        assert 'max-age' not in res.headers['Set-Cookie']
+
+        assert res.headers['Location'] == content_host_str
+
+        res = self.content_get(res.headers['Location'])
+
+        assert '"food": "bar"' in res.text
+
+    def test_wipe_app_cookie(self):
+        # remove app-domain cookie
+        self.testapp.cookiejar.clear(domain='app-host.local')
+
+        # new session -- logged in user no longer avail
+        res = self.app_get('/test/default-collection/http://httpbin.org/get?food=bar', status=404)
+
+        res = self.content_get('/test/default-collection/mp_/http://httpbin.org/get?food=bar', status=200)
+
+        # create new temp session
+        self.set_uuids('Recording', ['recx'])
+
+        res = self.app_get('/_new/temp/recx/record/http://httpbin.org/get?food=bar', status=302)
+        top_path = res.headers['Location']
+        res = self.app_get(top_path, status=200)
+
+        res = self.app_get('/api/v1/auth/curr_user')
+        TestAppContentDomain.anon_user = res.json['user']['username']
+
+        assert '/' + self.anon_user + '/' in top_path
+
+        # 404, wrong content cookie
+        res = self.testapp.get('/{user}/temp/recx/record/mp_/http://httpbin.org/get?food=bar'.format(user=self.anon_user),
+                               headers={'Host': 'content-host',
+                                        'Referer': top_path}, status=307)
+
+        assert 'http://app-host/_set_session' in res.headers['Location']
+
+        res = self.app_get(res.headers['Location'], status=302)
+        assert 'http://content-host/_set_session' in res.headers['Location']
+
+        res = self.content_get(res.headers['Location'], status=302)
+
+        content_host_str = 'http://content-host/{user}/temp/recx/record/mp_/http://httpbin.org/get?food=bar'.format(user=self.anon_user)
+
+        assert self.testapp.cookies['__test_sesh'] in res.headers['Set-Cookie']
+
+        assert res.headers['Location'] == content_host_str
+
+        res = self.content_get(res.headers['Location'])
+
+        assert '"food": "bar"' in res.text
+
+    def test_not_found_redir_back(self):
+        url = '/{user}/temp/mp_/http://httpbin.org/get?bood=far'.format(user=self.anon_user)
+        refer_url = 'http://app-host' + url.replace('mp_/', '')
+
+        res = self.testapp.get(url,
+                               headers={'Host': 'content-host',
+                                        'Referer': refer_url},
+                               status=307)
+
+        res = self.app_get(res.headers['Location'])
+
+        assert 'Set-Cookie' not in res.headers
+
+        assert res.headers['Location'].endswith(url)
+
+        res = self.testapp.get(res.headers['Location'],
+                               headers={'Host': 'content-host',
+                                        'Referer': refer_url},
+                               status=404)
+
 

--- a/webrecorder/test/test_app_content_domain.py
+++ b/webrecorder/test/test_app_content_domain.py
@@ -342,7 +342,7 @@ class TestAppContentDomain(FullStackTests):
 
         assert 'http://app-host/_set_session' in res.headers['Location']
 
-        assert 'curr_cookie' in res.headers['Location']
+        assert 'content_cookie' in res.headers['Location']
 
         res = self.app_get(res.headers['Location'], status=302)
         assert 'http://content-host/_set_session' in res.headers['Location']
@@ -379,7 +379,7 @@ class TestAppContentDomain(FullStackTests):
 
         assert 'http://app-host/_set_session' in res.headers['Location']
 
-        assert 'curr_cookie' in res.headers['Location']
+        assert 'content_cookie' in res.headers['Location']
 
         res = self.app_get(res.headers['Location'], status=302)
         assert 'http://content-host/_set_session' in res.headers['Location']
@@ -398,7 +398,7 @@ class TestAppContentDomain(FullStackTests):
                                         'Referer': refer_url},
                                status=307)
 
-        assert 'curr_cookie' in res.headers['Location']
+        assert 'content_cookie' in res.headers['Location']
 
         res = self.app_get(res.headers['Location'])
 

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -14,6 +14,7 @@ from webrecorder.apiutils import api_decorator, wr_api_spec
 # ============================================================================
 class BaseController(object):
     SKIP_SESH_CHECK = '__skip:{id}:{url}'
+    TS_MOD_CHECK = re.compile('[\d]+mp_/')
 
     def __init__(self, *args, **kwargs):
         self.app = kwargs['app']
@@ -72,7 +73,9 @@ class BaseController(object):
 
         app_prefix = request.environ['wsgi.url_scheme'] + '://' + self.app_host
 
-        if referer != app_prefix + request_uri.replace('mp_/', ''):
+        replace_with = '/' if self.TS_MOD_CHECK.search(request_uri) else ''
+
+        if referer != app_prefix + request_uri.replace('mp_/', replace_with):
             return False
 
         skip_key = self.SKIP_SESH_CHECK.format(url=request_uri, id=self.get_session().get_id())

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -107,10 +107,10 @@ class BaseController(object):
         if not self.redis.set(skip_key, 1, nx=True, ex=self.SKIP_REDIR_LOCK_TTL):
             return False
 
-        # redirect to /_set_session, include curr_cookie
+        # redirect to /_set_session, include content_cookie
         query = {
                  'path': request_uri,
-                 'curr_cookie': request.environ.get('webrec.sesh_cookie', '')
+                 'content_cookie': request.environ.get('webrec.sesh_cookie', '')
                 }
 
         redir_url = app_prefix + '/_set_session?' + urlencode(query)

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -13,7 +13,8 @@ from webrecorder.apiutils import api_decorator, wr_api_spec
 
 # ============================================================================
 class BaseController(object):
-    SKIP_SESH_CHECK = '__skip:{id}:{url}'
+    SKIP_REDIR_LOCK_KEY = '__skip:{id}:{url}'
+    SKIP_REDIR_LOCK_TTL = 10
     TS_MOD_CHECK = re.compile('[\d]+mp_/')
 
     def __init__(self, *args, **kwargs):
@@ -59,29 +60,54 @@ class BaseController(object):
         return request.environ.get('HTTP_HOST') == self.content_host
 
     def _wrong_content_session_redirect(self):
+        """ Determine if this may be an incorrect content session
+        for the current app session. If so, redirect to /_set_session
+        to reset cookie
+        """
+
+        # only applies if app_host and content_host are different
         if not self.app_host or not self.content_host:
             return False
 
-        referer = request.headers.get('Referer')
-        if not referer:
+        # must have a referrer
+        referrer = request.headers.get('Referer')
+        if not referrer:
             return False
 
         request_uri = request.environ['REQUEST_URI']
 
+        # referrer must be the exact content url, from app_host and without the modifier:
+        #
+        # Referer: https://app-host/user/coll/record/rec/https://example.com/
+        # request_uri: /https://content-host/user/coll/record/rec/mp_/https://example.com/
+        #
+        # or, with timestamp:
+        #
+        # Referer: https://app-host/user/coll/2018010203000000/https://example.com/
+        # request_uri: /https://content-host/user/coll/2018010203000000mp_/https://example.com/
+        #
+
+        # request must contain mp_/ modifier
         if 'mp_/' not in request_uri:
             return False
 
         app_prefix = request.environ['wsgi.url_scheme'] + '://' + self.app_host
 
+        # remove extra '/' only if timestamp before mp_/
         replace_with = '/' if self.TS_MOD_CHECK.search(request_uri) else ''
 
-        if referer != app_prefix + request_uri.replace('mp_/', replace_with):
+        # check referrer match (as above)
+        if referrer != app_prefix + request_uri.replace('mp_/', replace_with):
             return False
 
-        skip_key = self.SKIP_SESH_CHECK.format(url=request_uri, id=self.get_session().get_id())
-        if not self.redis.set(skip_key, 1, nx=True, ex=5):
+        # additional 'lock' to avoid redirect loop, if already just redirected
+        # (key should be set for 10 secs) we already have the correct session,
+        # return a regular 404
+        skip_key = self.SKIP_REDIR_LOCK_KEY.format(url=request_uri, id=self.get_session().get_id())
+        if not self.redis.set(skip_key, 1, nx=True, ex=self.SKIP_REDIR_LOCK_TTL):
             return False
 
+        # redirect to /_set_session, include curr_cookie
         query = {
                  'path': request_uri,
                  'curr_cookie': request.environ.get('webrec.sesh_cookie', '')

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -398,6 +398,9 @@ class ContentController(BaseController, RewriterApp):
                 self.set_options_headers(self.content_host, self.app_host)
                 response.headers['Cache-Control'] = 'no-cache'
 
+                if sesh.is_same_session(request.query.getunicode('curr_cookie')):
+                    redirect(url + request.query.getunicode('path'))
+
                 cookie = quote(request.environ.get('webrec.sesh_cookie', ''))
                 url += '/_set_session?{0}&cookie={1}'.format(request.environ['QUERY_STRING'], cookie)
                 redirect(url)
@@ -731,6 +734,8 @@ class ContentController(BaseController, RewriterApp):
 
             if self.content_error_redirect:
                 return redirect(self.content_error_redirect + '?' + urlencode(err_context), code=307)
+            elif self._wrong_content_session_redirect():
+                return
             else:
                 return handle_error(err_context)
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -400,7 +400,7 @@ class ContentController(BaseController, RewriterApp):
 
                 # if already have same session, just redirect back
                 # likely a real 404 not found
-                if sesh.is_same_session(request.query.getunicode('curr_cookie')):
+                if sesh.is_same_session(request.query.getunicode('content_cookie')):
                     redirect(url + request.query.getunicode('path'))
 
                 cookie = quote(request.environ.get('webrec.sesh_cookie', ''))

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -398,6 +398,8 @@ class ContentController(BaseController, RewriterApp):
                 self.set_options_headers(self.content_host, self.app_host)
                 response.headers['Cache-Control'] = 'no-cache'
 
+                # if already have same session, just redirect back
+                # likely a real 404 not found
                 if sesh.is_same_session(request.query.getunicode('curr_cookie')):
                     redirect(url + request.query.getunicode('path'))
 

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -428,6 +428,9 @@ class MainController(BaseController):
                     return
 
                 else:
+                    if self._wrong_content_session_redirect():
+                        return
+
                     return error_view(out)
 
             if isinstance(out.exception, dict):
@@ -473,6 +476,7 @@ class MainController(BaseController):
             orig_url += '?' + request.urlparts.query
 
         full_url = host + urljoin(url, orig_url)
+
         response.status = 307
         response.set_header('Location', full_url)
         return True

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -93,6 +93,17 @@ class Session(object):
         sesh_id, is_restricted = result
         self.set_id(sesh_id)
 
+    def is_same_session(self, cookie):
+        if not cookie:
+            return False
+
+        result = self.sesh_manager.signed_cookie_to_id(cookie)
+        if not result:
+            return False
+
+        sesh_id, is_restricted = result
+        return self._sesh['id'] == sesh_id
+
     def set_id(self, id):
         self._sesh['id'] = id
         self.is_restricted = True


### PR DESCRIPTION
It is possible (not entirely clear why!) for app cookie and content cookie to become out of sync, eg. a new session is set on the app cookie, but content cookie is stale.

Currently, this results in a 404 when loading any content and is difficult to recover from.

This fixes the issue by attempting to reset the content cookie on certain types of 404s.

If a content 404 is found:
- detect if `Referer` is the app request to same page to determine if its a top-level page, and check that redir lock is not set.
- if the referrer matches, redirect to `app-host/_set_session`, including `content_cookie` as extra param. set skip lock for 10 seconds to avoid redirect loop.
- if `/_set_session` detects that `content_cookie` is different from current session, continue session reset. otherwise, redirect back, and serve a 404.
- continue the `content/_set_session` path to set a new content session