### PR TITLE
Fix anonymous session not being saved!

### DIFF
--- a/webrecorder/test/test_auto_login.py
+++ b/webrecorder/test/test_auto_login.py
@@ -17,7 +17,8 @@ class TestAutoLogin(FullStackTests):
     @classmethod
     def setup_class(cls, **kwargs):
         os.environ['AUTO_LOGIN_USER'] = 'test'
-        super(TestAutoLogin, cls).setup_class(temp_worker=True, storage_worker=True)
+        super(TestAutoLogin, cls).setup_class(temp_worker=True, storage_worker=True,
+                                              init_anon=False)
 
         cls.manager = CLIUserManager()
 

--- a/webrecorder/test/test_create_new_api.py
+++ b/webrecorder/test/test_create_new_api.py
@@ -22,17 +22,22 @@ class TestCreateNewAPISeparateDomains(FullStackTests):
         os.environ['CONTENT_HOST'] = ''
         os.environ['APP_HOST'] = ''
 
-    def test_empty_temp_user(self):
+    def test_new_temp_user_wrong_host(self):
         res = self.testapp.post('/api/v1/auth/anon_user', headers={'Host': 'app-host'})
         assert res.json['user']['username']
         username = res.json['user']['username']
 
+        self.assert_temp_user_sesh(username)
+
+        # incorrect host, redirect
         res = self.testapp.get('/api/v1/user/' + username, status=302)
         assert res.headers['Location'] == 'http://app-host/api/v1/user/' + username
 
     def test_init_anon(self):
         res = self.testapp.post('/api/v1/auth/anon_user', headers={'Host': 'app-host'})
         TestCreateNewAPISeparateDomains.anon_user = res.json['user']['username']
+
+        self.assert_temp_user_sesh(TestCreateNewAPISeparateDomains.anon_user)
 
         assert res.json['user']['username'] == self.anon_user
         assert res.json['user']['space_utilization']['used'] == 0
@@ -77,7 +82,6 @@ class TestCreateNewAPISeparateDomains(FullStackTests):
                                headers={'Host': 'app-host'})
 
         assert res.json['recording']['desc'] == 'Rec Session Description Here'
-
 
     def test_api_new_extract_browser(self):
         params = {'coll': 'temp',

--- a/webrecorder/test/test_external.py
+++ b/webrecorder/test/test_external.py
@@ -37,6 +37,8 @@ class TestExternalColl(FullStackTests):
         res = self.testapp.post('/api/v1/auth/anon_user', headers={'Host': 'app-host'})
         TestExternalColl.anon_user = res.json['user']['username']
 
+        self.assert_temp_user_sesh(TestExternalColl.anon_user)
+
         res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user),
                                      headers={'Host': 'app-host'},
                                      params=params)

--- a/webrecorder/test/test_pending.py
+++ b/webrecorder/test/test_pending.py
@@ -158,8 +158,8 @@ class TestPending(FullStackTests):
         assert self.get_pending_count('rec-a') == 0
         assert self.get_pending_size('rec-a') == 0
 
-        # assert 1 cdxj entry (deduped)
-        assert int(self.redis.zcard('r:rec-a:cdxj')) == 1
+        # assert 5 cdxj entry (deduped, revisit records written)
+        assert int(self.redis.zcard('r:rec-a:cdxj')) == 5
 
         # UNIQUE URLS
         # add param= to generate unique url
@@ -177,8 +177,8 @@ class TestPending(FullStackTests):
         assert self.get_pending_count('rec-a') == 0
         assert self.get_pending_size('rec-a') == 0
 
-        # assert 6 cdxj entries
-        assert int(self.redis.zcard('r:rec-a:cdxj')) == 6
+        # assert 10 cdxj entries
+        assert int(self.redis.zcard('r:rec-a:cdxj')) == 10
 
         # assert collection size increased
         coll, rec = self.get_coll_rec(self.anon_user, 'temp', '')

--- a/webrecorder/test/test_pending.py
+++ b/webrecorder/test/test_pending.py
@@ -159,7 +159,11 @@ class TestPending(FullStackTests):
         assert self.get_pending_size('rec-a') == 0
 
         # assert 5 cdxj entry (deduped, revisit records written)
-        assert int(self.redis.zcard('r:rec-a:cdxj')) == 5
+        all_cdxj = self.redis.zrange('r:rec-a:cdxj', 0, -1)
+        assert len(all_cdxj) == 5
+
+        # assert 4 are revisit records
+        assert len([cdxj for cdxj in all_cdxj if 'revisit' in cdxj]) == 4
 
         # UNIQUE URLS
         # add param= to generate unique url
@@ -178,7 +182,11 @@ class TestPending(FullStackTests):
         assert self.get_pending_size('rec-a') == 0
 
         # assert 10 cdxj entries
-        assert int(self.redis.zcard('r:rec-a:cdxj')) == 10
+        all_cdxj = self.redis.zrange('r:rec-a:cdxj', 0, -1)
+        assert len(all_cdxj) == 10
+
+        # assert 4 are revisit records
+        assert len([cdxj for cdxj in all_cdxj if 'revisit' in cdxj]) == 4
 
         # assert collection size increased
         coll, rec = self.get_coll_rec(self.anon_user, 'temp', '')

--- a/webrecorder/test/test_storage_commit.py
+++ b/webrecorder/test/test_storage_commit.py
@@ -22,7 +22,8 @@ class BaseStorageCommit(FullStackTests):
     def setup_class(cls):
         os.environ['AUTO_LOGIN_USER'] = 'test'
         super(BaseStorageCommit, cls).setup_class(extra_config_file='test_cdxj_cache_config.yaml',
-                                                  storage_worker=True)
+                                                  storage_worker=True,
+                                                  init_anon=False)
 
         cls.set_uuids('Recording', count(500))
         cls.set_uuids('Collection', count(100))

--- a/webrecorder/test/test_ws.py
+++ b/webrecorder/test/test_ws.py
@@ -33,7 +33,8 @@ class TestWS(FullStackTests):
     def test_user_cred(self):
         res = self.post_json('/api/v1/auth/anon_user')
         TestWS.anon_user = res.json()['user']['username']
-        assert self.sesh_redis.hget('t:{0}'.format(TestWS.anon_user))
+
+        self.assert_temp_user_sesh(TestWS.anon_user)
 
     def test_create_recording(self):
         self.set_uuids('Recording', ['rec'])

--- a/webrecorder/test/test_ws.py
+++ b/webrecorder/test/test_ws.py
@@ -33,6 +33,7 @@ class TestWS(FullStackTests):
     def test_user_cred(self):
         res = self.post_json('/api/v1/auth/anon_user')
         TestWS.anon_user = res.json()['user']['username']
+        assert self.sesh_redis.hget('t:{0}'.format(TestWS.anon_user))
 
     def test_create_recording(self):
         self.set_uuids('Recording', ['rec'])

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -88,6 +88,7 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
         webrecorder.maincontroller.load_wr_config = load_wr_config
 
         cls.redis = FakeStrictRedis.from_url(os.environ['REDIS_BASE_URL'], decode_responses=True)
+        cls.sesh_redis = FakeStrictRedis.from_url(os.environ['REDIS_SESSION_URL'], decode_responses=True)
 
         cls.custom_init(kwargs)
 
@@ -100,6 +101,7 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
         if init_anon:
             res = cls.testapp.post('/api/v1/auth/anon_user')
             cls.anon_user = res.json['user']['username']
+            cls.assert_temp_user_sesh(cls.anon_user)
         else:
             cls.anon_user = None
 
@@ -119,6 +121,10 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
     @classmethod
     def get_curr_dir(cls):
         return os.path.dirname(os.path.realpath(__file__))
+
+    @classmethod
+    def assert_temp_user_sesh(cls, anon_user):
+        assert cls.sesh_redis.get('t:{0}'.format(anon_user)) != ''
 
     @classmethod
     def get_coll_rec(cls, user, coll_name, rec):

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -126,7 +126,8 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
     def assert_temp_user_sesh(cls, anon_user):
         sesh = cls.sesh_redis.get('t:{0}'.format(anon_user))
         assert sesh
-        assert cls.sesh_redis.get('sesh:{0}'.format(sesh)) != ''
+        # ensure session key exists and is expiring
+        assert cls.sesh_redis.ttl('sesh:{0}'.format(sesh)) > 0
 
     @classmethod
     def get_coll_rec(cls, user, coll_name, rec):

--- a/webrecorder/test/testutils.py
+++ b/webrecorder/test/testutils.py
@@ -124,7 +124,9 @@ class BaseWRTests(FakeRedisTests, TempDirTests, BaseTestClass):
 
     @classmethod
     def assert_temp_user_sesh(cls, anon_user):
-        assert cls.sesh_redis.get('t:{0}'.format(anon_user)) != ''
+        sesh = cls.sesh_redis.get('t:{0}'.format(anon_user))
+        assert sesh
+        assert cls.sesh_redis.get('sesh:{0}'.format(sesh)) != ''
 
     @classmethod
     def get_coll_rec(cls, user, coll_name, rec):

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -62,11 +62,19 @@ class Session(object):
 
         message, msg_type = self.pop_message()
 
+        # TODO: remove template params as not used with frontend?
         params = {'curr_user': self.curr_user,
                   'curr_role': self.curr_role,
                   'csrf': self.get_csrf(),
                   'message': message,
-                  'msg_type': msg_type}
+                  'msg_type': msg_type,
+                 }
+
+        if self.curr_role == 'anon':
+            params['anon_ttl'] = ttl
+
+        if sesh_manager.auto_login_user:
+            params['auto_login'] = True
 
         self.template_params = params
 
@@ -131,8 +139,14 @@ class Session(object):
         return self._sesh.get(name, value)
 
     def set_anon(self):
-        if not self.curr_user:
-            self['anon'] = self.anon_user
+        if self.curr_user:
+            return
+
+        self['anon'] = self.anon_user
+
+        self.curr_role = 'anon'
+
+        self.redis.set(self.TEMP_KEY.format(self.anon_user), self._sesh['id'])
 
     def is_anon(self, user=None):
         anon = self._sesh.get('anon')
@@ -308,18 +322,6 @@ class RedisSessionMiddleware(CookieGuard):
                           ttl,
                           is_restricted,
                           self)
-
-        #if force_save:
-        #    session.save()
-
-        if session.curr_role == 'anon':
-            session.template_params['anon_ttl'] = ttl
-
-            anon_user = session['anon']
-            self.redis.set(Session.TEMP_KEY.format(anon_user), sesh_id)
-
-        if self.auto_login_user:
-            session.template_params['auto_login'] = True
 
         environ['webrec.template_params'] = session.template_params
         environ['webrec.session'] = session


### PR DESCRIPTION
Fix `Session.set_anon` to explicitly set the temp user key `t:<temp user>` to ensure the anon session is not wiped by tempchecker!

Previously, anonymous session was only being saved on subsequent requests (in `init_session()`),
causing a subtle bug that would allow session to not be inited.

Update tests to add `assert_temp_user_sesh()` to ensure that the temp user key is correctly set after anon user is inited with `/api/v1/auth/anon_user`

Other tests fix: fix test_pending to include `revisit` record counts.