### PR TITLE
warc download: change the extension on download WARCs from '.warc.gz'…

### DIFF
--- a/webrecorder/test/test_anon_workflow.py
+++ b/webrecorder/test/test_anon_workflow.py
@@ -486,6 +486,7 @@ class TestTempContent(FullStackTests):
         self.set_downloaded()
 
         assert res.headers['Content-Disposition'].startswith("attachment; filename*=UTF-8''my-rec2-")
+        assert res.headers['Content-Disposition'].endswith('.warc')
 
         warcin = self._get_dechunked(res.body)
 

--- a/webrecorder/webrecorder/config/wr.yaml
+++ b/webrecorder/webrecorder/config/wr.yaml
@@ -76,7 +76,7 @@ recorder_accept_colls:
 
 # Download paths
 download_paths:
-    filename: '{title}-{timestamp}.warc.gz'
+    filename: '{title}-{timestamp}.warc'
 
     rec: '{host}/{user}/{coll}/{rec}/$download'
     coll: '{host}/{user}/{coll}/$download'


### PR DESCRIPTION
… to '.warc' to:

- avoid automatic decompression in safari
- avoid user-double clicking on the WARC and decompressing
(since WARCs use multi-gzip members, default decompression by other tools results in broken WARCs)