### PR TITLE
Simplify Anon Session

### DIFF
--- a/frontend/src/containers/App/App.js
+++ b/frontend/src/containers/App/App.js
@@ -11,7 +11,7 @@ import { asyncConnect } from 'redux-connect';
 import { DragDropContext } from 'react-dnd';
 
 import { isLoaded as isAuthLoaded,
-         load as loadAuth, loadAnon } from 'redux/modules/auth';
+         load as loadAuth } from 'redux/modules/auth';
 
 import { UserManagement } from 'containers';
 
@@ -295,13 +295,7 @@ const initalData = [
       const state = getState();
 
       if (!isAuthLoaded(state)) {
-        return dispatch(loadAuth()).then(
-          (auth) => {
-            if (auth.user.anon) {
-              return dispatch(loadAnon());
-            }
-          }
-        );
+        return dispatch(loadAuth());
       }
 
       return undefined;

--- a/frontend/src/redux/modules/auth.js
+++ b/frontend/src/redux/modules/auth.js
@@ -9,10 +9,6 @@ const LOAD = 'wr/auth/LOAD';
 const LOAD_SUCCESS = 'wr/auth/LOAD_SUCCESS';
 const LOAD_FAIL = 'wr/auth/LOAD_FAIL';
 
-const LOAD_ANON = 'wr/auth/LOAD_ANON';
-const LOAD_ANON_SUCCESS = 'wr/auth/LOAD_ANON_SUCCESS';
-const LOAD_ANON_FAIL = 'wr/auth/LOAD_ANON_FAIL';
-
 const LOGIN = 'wr/auth/LOGIN';
 export const LOGIN_SUCCESS = 'wr/auth/LOGIN_SUCCESS';
 const LOGIN_FAIL = 'wr/auth/LOGIN_FAIL';
@@ -209,14 +205,6 @@ export function load(include_colls = true) {
     promise: client => client.get(`${apiPath}/auth/curr_user`, {
       params: { include_colls }
     })
-  };
-}
-
-
-export function loadAnon() {
-  return {
-    types: [LOAD_ANON, LOAD_ANON_SUCCESS, LOAD_ANON_FAIL],
-    promise: client => client.post(`${apiPath}/auth/anon_user`)
   };
 }
 

--- a/webrecorder/test/test_app_content_domain.py
+++ b/webrecorder/test/test_app_content_domain.py
@@ -389,21 +389,36 @@ class TestAppContentDomain(FullStackTests):
         assert res.status_code == 302
         assert self.testapp.cookies['__test_sesh'] in res.headers['Set-Cookie']
 
-    def test_not_found_redir_back(self):
+    def test_not_found(self):
         url = '/test/default-collection/mp_/http://httpbin.org/get?bood=far'
         refer_url = 'http://app-host' + url.replace('mp_/', '')
 
         res = self.testapp.get(url,
                                headers={'Host': 'content-host',
                                         'Referer': refer_url},
-                               status=307)
+                               status=404)
 
-        assert 'content_cookie' in res.headers['Location']
+    def test_not_found_no_cookie(self):
+        # clear content cookie
+        self.testapp.cookiejar.clear(domain='content-host.local')
 
+        url = '/test/default-collection/mp_/http://httpbin.org/get?bood=far'
+        refer_url = 'http://app-host' + url.replace('mp_/', '')
+
+        res = self.testapp.get(url,
+                               headers={'Host': 'content-host',
+                                        'Referer': refer_url},
+                               status=302)
+
+        assert 'content_cookie' not in res.headers['Location']
+
+        # app /_set_session
         res = self.app_get(res.headers['Location'])
 
-
         assert 'Set-Cookie' not in res.headers
+
+        # content /_set_session
+        res = self.content_get(res.headers['Location'])
 
         assert res.headers['Location'].endswith(url)
 
@@ -412,4 +427,23 @@ class TestAppContentDomain(FullStackTests):
                                         'Referer': refer_url},
                                status=404)
 
+    def test_public_no_cookie_needed(self):
+        params = {'public': True,
+                 }
+
+        res = self.testapp.post_json('/api/v1/collection/default-collection?user=test',
+                            headers={'Host': 'app-host'},
+                            params=params, status=200)
+
+        # clear content cookie
+        self.testapp.cookiejar.clear(domain='content-host.local')
+
+        url = '/test/default-collection/2018mp_/http://httpbin.org/get?food=bar'
+        refer_url = 'http://app-host' + url.replace('mp_/', '/')
+        res = self.testapp.get(url,
+                               headers={'Host': 'content-host',
+                                        'Referer': refer_url}, status=200)
+
+        assert 'Set-Cookie' in res.headers
+        assert '"food": "bar"' in res.text
 

--- a/webrecorder/test/test_ws.py
+++ b/webrecorder/test/test_ws.py
@@ -49,7 +49,8 @@ class TestWS(FullStackTests):
 
     def test_ws_record_init(self):
         TestWS.ws = websocket.WebSocket()
-        TestWS.ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp&rec=rec&type=record'.format(self.app_port, user=self.anon_user))
+        TestWS.ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp&rec=rec&type=record'.format(self.app_port, user=self.anon_user),
+                          header=['Cookie: __test_sesh=' + self.sesh.cookies['__test_sesh']])
 
         msg = json.loads(self.ws.recv())
 
@@ -89,7 +90,8 @@ class TestWS(FullStackTests):
 
     def test_ws_replay(self):
         replay_ws = websocket.WebSocket()
-        replay_ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp'.format(self.app_port, user=self.anon_user))
+        replay_ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp'.format(self.app_port, user=self.anon_user),
+                          header=['Cookie: __test_sesh=' + self.sesh.cookies['__test_sesh']])
 
         msg = json.loads(replay_ws.recv())
 
@@ -113,7 +115,8 @@ class TestWS(FullStackTests):
 
     def test_ws_extract_update_with_stats(self):
         ex_ws = websocket.WebSocket()
-        ex_ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp&rec=ex&type=extract&url=http://geocities.com/'.format(self.app_port, user=self.anon_user))
+        ex_ws.connect('ws://localhost:{0}/_client_ws?user={user}&coll=temp&rec=ex&type=extract&url=http://geocities.com/'.format(self.app_port, user=self.anon_user),
+                      header=['Cookie: __test_sesh=' + self.sesh.cookies['__test_sesh']])
 
         def assert_size():
             msg = json.loads(ex_ws.recv())

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -120,6 +120,10 @@ class Session(object):
         self.should_copy_cookie = True
         self.should_save = False
 
+    def get_cookie(self):
+        return self.sesh_manager.id_to_signed_cookie(self._sesh['id'],
+                                                     self.is_restricted)
+
     def save(self):
         self.should_save = True
 
@@ -401,8 +405,7 @@ class RedisSessionMiddleware(CookieGuard):
         expires = datetime.utcnow() + timedelta(seconds=duration)
 
         # set cookie
-        sesh_cookie = self.id_to_signed_cookie(session['id'],
-                                               session.is_restricted)
+        sesh_cookie = session.get_cookie()
 
         value = '{0}={1}; Path=/; HttpOnly'
 

--- a/webrecorder/webrecorder/websockcontroller.py
+++ b/webrecorder/webrecorder/websockcontroller.py
@@ -43,6 +43,9 @@ class WebsockController(BaseController):
         rec = request.query.getunicode('rec')
         recording = collection.get_recording(rec)
 
+        if not self.access.can_read_coll(collection):
+            self._raise_error(404, 'not_found')
+
         reqid = request.query.get('reqid')
         if reqid:
             sesh_id = self.browser_mgr.browser_sesh_id(reqid)


### PR DESCRIPTION
Auto-Init session rather than requiring a POST to `anon_user` api, also make public collection content accessible without a cookie (auto-set cookie on first use).