### PR TITLE
Cookie Check: Relax Refer Check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,7 @@ before_install: |
 
 install:
   - cd webrecorder
+  - pip install 'urllib3==1.23'
   - python setup.py install
   - pip install coverage pytest-cov codecov
   - pip install 'pyinstaller==3.3'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,7 @@ install:
   - "python -m pip install --upgrade pip"
   - "pip install -U setuptools"
   - "pip install pyinstaller==3.3"
+  - "pip install urllib3==1.23"
   - "pip install cffi"
   - "pip install pyopenssl"
   - "pip install pyyaml"

--- a/webrecorder/test/test_app_content_domain.py
+++ b/webrecorder/test/test_app_content_domain.py
@@ -372,10 +372,9 @@ class TestAppContentDomain(FullStackTests):
 
     def test_reset_content_cookie_replay_ts(self):
         url = '/test/default-collection/2018mp_/http://httpbin.org/get?food=bar'
-        refer_url = 'http://app-host' + url.replace('mp_/', '/')
         res = self.testapp.get(url,
                                headers={'Host': 'content-host',
-                                        'Referer': refer_url})
+                                        'Referer': 'http://app-host/'})
 
         assert 'http://app-host/_set_session' in res.headers['Location']
 

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -1,4 +1,3 @@
-import re
 import os
 
 from bottle import request, HTTPError, redirect as bottle_redirect, response
@@ -15,7 +14,6 @@ from webrecorder.apiutils import api_decorator, wr_api_spec
 class BaseController(object):
     SKIP_REDIR_LOCK_KEY = '__skip:{id}:{url}'
     SKIP_REDIR_LOCK_TTL = 10
-    TS_MOD_CHECK = re.compile('[\d]+mp_/')
 
     def __init__(self, *args, **kwargs):
         self.app = kwargs['app']

--- a/webrecorder/webrecorder/basecontroller.py
+++ b/webrecorder/webrecorder/basecontroller.py
@@ -76,28 +76,14 @@ class BaseController(object):
 
         request_uri = request.environ['REQUEST_URI']
 
-        # referrer must be the exact content url, from app_host and without the modifier:
-        #
-        # Referer: https://app-host/user/coll/record/rec/https://example.com/
-        # request_uri: /https://content-host/user/coll/record/rec/mp_/https://example.com/
-        #
-        # or, with timestamp:
-        #
-        # Referer: https://app-host/user/coll/2018010203000000/https://example.com/
-        # request_uri: /https://content-host/user/coll/2018010203000000mp_/https://example.com/
-        #
-
         # request must contain mp_/ modifier
         if 'mp_/' not in request_uri:
             return False
 
         app_prefix = request.environ['wsgi.url_scheme'] + '://' + self.app_host
 
-        # remove extra '/' only if timestamp before mp_/
-        replace_with = '/' if self.TS_MOD_CHECK.search(request_uri) else ''
-
-        # check referrer match (as above)
-        if referrer != app_prefix + request_uri.replace('mp_/', replace_with):
+        # referrer must be from the app host, start with app_prefix
+        if not referrer.startswith(app_prefix):
             return False
 
         # additional 'lock' to avoid redirect loop, if already just redirected


### PR DESCRIPTION
Relax referrer check on content session cookie mismatch to just check for app host prefix rather than exact url match to account for different referrers being sent in Firefox.
The wrong session check only happens once per incorrect session, no need to have more strict match.