### PR TITLE
Player Fix: Ensure Collection CDXJ Never Expires in Player

### DIFF
--- a/webrecorder/webrecorder/config/standalone_player.yaml
+++ b/webrecorder/webrecorder/config/standalone_player.yaml
@@ -11,6 +11,7 @@ init_import_user: 'local'
 init_import_coll: 'collection'
 
 cdxj_key_templ: 'c:{coll}:cdxj'
+coll_cdxj_ttl: -1
 
 max_detect_pages: 0
 

--- a/webrecorder/webrecorder/models/pages.py
+++ b/webrecorder/webrecorder/models/pages.py
@@ -195,7 +195,8 @@ class PagesMixin(object):
             all_bookmarks[page] = json.dumps(bookmark)
 
         self.redis.hmset(key, all_bookmarks)
-        self.redis.expire(key, self.COLL_CDXJ_TTL)
+        if self.COLL_CDXJ_TTL > 0:
+            self.redis.expire(key, self.COLL_CDXJ_TTL)
 
         return filtered_bookmarks
 


### PR DESCRIPTION
set coll_cdxj_ttl to -1 for player to prevent collection cdxj key from expiring

collection: check if COLL_CDXJ_TTL is >0 before calling expire()
tests: update player test to ensure collection cdxj key will not expire