### PR TITLE
rate limits: add 'rate-unlimited-archivist' role which skips the rate…

### DIFF
--- a/webrecorder/test/test_admin_api.py
+++ b/webrecorder/test/test_admin_api.py
@@ -56,7 +56,7 @@ class TestAdminAPI(FullStackTests):
         res = self.testapp.get('/api/v1/admin/user_roles')
         assert set(res.json['roles']) == {'admin',
                                           'beta-archivist',
-                                          'mounts-archivist',
+                                          'rate-unlimited-archivist',
                                           'public-archivist',
                                           'archivist'}
 

--- a/webrecorder/test/test_rate_limits.py
+++ b/webrecorder/test/test_rate_limits.py
@@ -2,6 +2,8 @@ from .testutils import FullStackTests
 import os
 import time
 
+from webrecorder.models.usermanager import CLIUserManager
+
 
 # ============================================================================
 class TestRateLimits(FullStackTests):
@@ -16,6 +18,7 @@ class TestRateLimits(FullStackTests):
         os.environ['RATE_LIMIT_RESTRICTED_MAX'] = str(cls.RESTRICT_LIMIT)
         os.environ['RATE_LIMIT_RESTRICTED_IPS'] = '255.255.255,10.0.0'
         super(TestRateLimits, cls).setup_class()
+        cls.user_manager = CLIUserManager()
 
     @classmethod
     def teardown_class(cls):
@@ -60,7 +63,9 @@ class TestRateLimits(FullStackTests):
 
         time.sleep(0.0)
         keys = self.redis.keys('ipr:10.0.0*')
-        assert int(self.redis.get(keys[0])) >= self.RESTRICT_LIMIT
+
+        TestRateLimits.limit = int(self.redis.get(keys[0]))
+        assert TestRateLimits.limit >= self.RESTRICT_LIMIT
 
 
         res = self.testapp.get('/{user}/temp/rec/record/mp_/http://httpbin.org/get?food=bar5'.format(user=self.anon_user),
@@ -69,3 +74,57 @@ class TestRateLimits(FullStackTests):
 
         assert res.status_code == 402
 
+    def test_create_rate_unlimited(self):
+        self.user_manager.create_user('user2@example.com', 'test-unlim', 'TestTest456', 'rate-unlimited-archivist', 'Test User')
+
+        params = {'username': 'test-unlim',
+                  'password': 'TestTest456',
+                 }
+
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
+        assert res.json['user']['username'] == 'test-unlim'
+        assert self.testapp.cookies['__test_sesh'] != ''
+
+    def test_record_not_limited(self):
+        self.set_uuids('Recording', ['rec'])
+        headers = {'X-Real-IP': '10.0.0.5'}
+        res = self.testapp.get('/_new/temp/rec/record/mp_/http://httpbin.org/get?food=bar', headers=headers, status=302)
+        res = res.follow(headers=headers)
+
+        assert '"food": "bar"' in res.text, res.text
+
+        time.sleep(0.0)
+        keys = self.redis.keys('ipr:10.0.0*')
+
+        assert int(self.redis.get(keys[0])) == TestRateLimits.limit
+
+        res = self.testapp.post_json('/api/v1/auth/logout', status=200)
+        assert res.json['success']
+
+    def test_create_rate_limited(self):
+        self.user_manager.create_user('user@example.com', 'test-lim', 'TestTest456', 'archivist', 'Test User')
+
+        params = {'username': 'test-lim',
+                  'password': 'TestTest456',
+                 }
+
+        res = self.testapp.post_json('/api/v1/auth/login', params=params)
+        assert res.json['user']['username'] == 'test-lim'
+        assert self.testapp.cookies['__test_sesh'] != ''
+
+    def test_record_logged_in_limited(self):
+        self.set_uuids('Recording', ['rec'])
+        headers = {'X-Real-IP': '10.0.0.5'}
+
+        res = self.testapp.get('/_new/temp/rec/record/mp_/http://httpbin.org/get?food=bar5',
+                               headers=headers, status=302)
+
+        res = res.follow(headers=headers, status=402)
+
+        time.sleep(0.0)
+        keys = self.redis.keys('ipr:10.0.0*')
+
+        assert int(self.redis.get(keys[0])) == TestRateLimits.limit
+
+        res = self.testapp.post_json('/api/v1/auth/logout', status=200)
+        assert res.json['success']

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -849,11 +849,12 @@ class ContentController(BaseController, RewriterApp):
 
     def check_rate_limit(self, user, remote_ip):
         # check rate limit and return ip used for further limiting
-        # if skipping limit
+        # if skipping limit, return empty string to avoid incrementing
+        # rate counter for this request
         res = user.is_rate_limited(remote_ip)
         if res == True:
             self._raise_error(402, 'rate_limit_exceeded')
-        # if None, then no rate limit at all, don't increment by ip
+        # if None, then no rate limit at all, return empty string
         elif res == None:
             return ''
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -159,6 +159,8 @@ class ContentController(BaseController, RewriterApp):
 
             browser_can_write = '1' if self.access.can_write_coll(collection) else '0'
 
+            remote_ip = self._get_remote_ip()
+
             # build kwargs
             kwargs = dict(user=user.name,
                           id=sesh.get_id(),
@@ -172,8 +174,8 @@ class ContentController(BaseController, RewriterApp):
                           inv_sources=inv_sources,
                           patch_rec=patch_rec,
 
-                          remote_ip=self._get_remote_ip(),
-                          ip=self._get_remote_ip(),
+                          remote_ip=remote_ip,
+                          ip=remote_ip,
 
                           browser=browser_id,
                           url=url,
@@ -468,8 +470,8 @@ class ContentController(BaseController, RewriterApp):
             remote_ip = info.get('remote_ip')
 
             if remote_ip and info['type'] in self.MODIFY_MODES:
-                if user.is_rate_limited(remote_ip):
-                    self._raise_error(402, 'rate_limit_exceeded')
+                remote_ip = self.check_rate_limit(user, remote_ip)
+                kwargs['ip'] = remote_ip
 
             resp = self.render_content(wb_url, kwargs, request.environ)
 
@@ -634,8 +636,7 @@ class ContentController(BaseController, RewriterApp):
 
             remote_ip = self._get_remote_ip()
 
-            if the_user.is_rate_limited(remote_ip):
-                self._raise_error(402, 'rate_limit_exceeded')
+            remote_ip = self.check_rate_limit(the_user, remote_ip)
 
             if inv_sources and inv_sources != '*':
                 #patch_rec_name = self.patch_of_name(rec, True)
@@ -845,6 +846,19 @@ class ContentController(BaseController, RewriterApp):
         remote_ip = remote_ip or request.environ.get('REMOTE_ADDR', '')
         remote_ip = remote_ip.rsplit('.', 1)[0]
         return remote_ip
+
+    def check_rate_limit(self, user, remote_ip):
+        # check rate limit and return ip used for further limiting
+        # if skipping limit
+        res = user.is_rate_limited(remote_ip)
+        if res == True:
+            self._raise_error(402, 'rate_limit_exceeded')
+        # if None, then no rate limit at all, don't increment by ip
+        elif res == None:
+            return ''
+
+        else:
+            return remote_ip
 
     ## RewriterApp overrides
     def get_base_url(self, wb_url, kwargs):

--- a/webrecorder/webrecorder/models/user.py
+++ b/webrecorder/webrecorder/models/user.py
@@ -268,12 +268,19 @@ class User(RedisUniqueComponent):
         else:
             return False
 
+    @property
+    def curr_role(self):
+        return self['role']
+
     def is_rate_limited(self, ip):
         if not self.rate_limit_hours or not self.rate_limit_max:
-            return False
+            return None
 
         if self.access.is_superuser():
-            return False
+            return None
+
+        if self.curr_role == 'rate-unlimited-archivist':
+            return None
 
         rate_key = self.RATE_LIMIT_KEY.format(ip=ip, H='')
         h = int(datetime.utcnow().strftime('%H'))

--- a/webrecorder/webrecorder/webreccork.py
+++ b/webrecorder/webrecorder/webreccork.py
@@ -120,8 +120,8 @@ class WebRecCork(Cork):
             cork.create_role('beta-archivist', 60)
         if 'public-archivist' not in roles:
             cork.create_role('public-archivist', 25)
-        if 'mounts-archivist' not in roles:
-            cork.create_role('mounts-archivist', 60)
+        if 'rate-unlimited-archivist' not in roles:
+            cork.create_role('rate-unlimited-archivist', 60)
 
 
 # ============================================================================


### PR DESCRIPTION
… limit

- don't increment rate counter if ignoring rate limit (for admin or rate-unlimited-archivis)
- User.is_rate_limited() returns False is not limited, None if limit is being skipped
- tests: ensure rate limit ignored for rate-unlimited-archivist, and rate counter not incremented