### PR TITLE
bind Redis to loopback interface to avoid open Redis port on host machine

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -140,7 +140,7 @@ services:
             - ./wr.env
 
         ports:
-            - 6379:6379
+            - 127.0.0.1:6379:6379
 
         volumes:
             - ./data:/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,9 +139,6 @@ services:
         env_file:
             - ./wr.env
 
-        ports:
-            - 127.0.0.1:6379:6379
-
         volumes:
             - ./data:/data
 


### PR DESCRIPTION
The Redis port is bound to 0.0.0.0 when running docker-compose with the given docker-compose file. From my understanding, the Webrecorder does not seem to need the Redis port to be open to function properly, so this would improve overall security on host machines without additional security measures in place.