### PR TITLE
Allow Uploading to External Anon User Collections 

### DIFF
--- a/webrecorder/test/test_external.py
+++ b/webrecorder/test/test_external.py
@@ -19,6 +19,7 @@ class TestExternalColl(FullStackTests):
         os.environ['CONTENT_ERROR_REDIRECT'] = 'http://external.example.com/error'
         os.environ['CONTENT_HOST'] = 'content-host'
         os.environ['APP_HOST'] = 'app-host'
+        cls.upload_filename = os.path.join(cls.get_curr_dir(), 'warcs', 'test_3_15_upload.warc.gz')
         super(TestExternalColl, cls).setup_class(init_anon=False)
 
     @classmethod
@@ -57,7 +58,7 @@ com,example)/fake 20180306181354 http://example.com/fake text/html 200 A6DESOVDZ
         assert res.json['success'] == 2
 
     def test_external_set_warc(self):
-        warc_path = 'file://' + os.path.join(self.get_curr_dir(), 'warcs', 'test_3_15_upload.warc.gz')
+        warc_path = 'file://' + self.upload_filename
 
         res = self.testapp.put_json('/api/v1/collection/external/warc?user={user}'.format(user=self.anon_user),
                                     params={'warcs': {'test.warc.gz': warc_path}},
@@ -72,6 +73,58 @@ com,example)/fake 20180306181354 http://example.com/fake text/html 200 A6DESOVDZ
         res = res.follow(headers={'Host': 'app-host'})
         res = res.follow(headers={'Host': 'content-host'})
         res = res.follow(headers={'Host': 'content-host'})
+
+        assert 'Example Domain' in res.text
+
+    def test_external_new_coll(self):
+        params = {'external': True,
+                  'title': 'external-upload-test'
+                 }
+
+        res = self.testapp.post('/api/v1/auth/anon_user', headers={'Host': 'app-host'})
+        TestExternalColl.anon_user = res.json['user']['username']
+
+        self.assert_temp_user_sesh(TestExternalColl.anon_user)
+
+        res = self.testapp.post_json('/api/v1/collections?user={user}'.format(user=self.anon_user),
+                                     headers={'Host': 'app-host'},
+                                     params=params)
+
+        assert res.json['collection']['slug'] == 'external-upload-test'
+
+    def test_external_upload(self):
+        with open(self.upload_filename, 'rb') as fh:
+            res = self.testapp.put('/api/v1/upload?filename=example.warc.gz&force-coll=external-upload-test',
+                                   params=fh.read(),
+                                   headers={'Host': 'app-host'})
+
+        res.charset = 'utf-8'
+        assert res.json['user'] == self.anon_user
+        assert res.json['upload_id'] != ''
+
+        upload_id = res.json['upload_id']
+        res = self.testapp.get('/api/v1/upload/{upload_id}?user={user}'.format(upload_id=upload_id, user=self.anon_user),
+                               headers={'Host': 'app-host'})
+
+        assert res.json['coll'] == 'external-upload-test'
+        assert res.json['coll_title'] == 'external-upload-test'
+        assert res.json['filename'] == 'example.warc.gz'
+        assert res.json['files'] == 1
+        assert res.json['total_size'] >= 3000
+        assert res.json['done'] == False
+
+        def assert_finished():
+            res = self.testapp.get('/api/v1/upload/{upload_id}?user={user}'.format(upload_id=upload_id, user=self.anon_user),
+                                   headers={'Host': 'app-host'})
+
+            assert res.json['done'] == True
+            assert res.json['size'] >= res.json['total_size']
+
+        self.sleep_try(0.2, 10.0, assert_finished)
+
+    def test_external_upload_replay(self):
+        res = self.testapp.get('/{user}/external-upload-test/mp_/http://example.com/'.format(user=self.anon_user),
+                               headers={'Host': 'content-host'})
 
         assert 'Example Domain' in res.text
 
@@ -103,6 +156,5 @@ com,example)/fake 20180306181354 http://example.com/fake text/html 200 A6DESOVDZ
                         'status': '404',
                         'error': 'no_such_collection',
                        }
-
 
 

--- a/webrecorder/webrecorder/apiutils.py
+++ b/webrecorder/webrecorder/apiutils.py
@@ -67,6 +67,7 @@ class WRAPISpec(object):
         'timestamp': 'Archived at Timestamp',
         'browser': 'Browser Used',
         'page_id': 'Page Id',
+        'upload_id': 'Upload Id',
     }
 
     opt_bool_params = {


### PR DESCRIPTION
- allow regular uploads into anon user external collections
- add /api/v1/upload and /api/v1/upload/<status> endpoints
- tests: update external api tests to include uploads