### PR TITLE
bulk add: optimize bulk add to avoid adding each bookmark one at a time

### DIFF
--- a/webrecorder/requirements.txt
+++ b/webrecorder/requirements.txt
@@ -7,6 +7,6 @@ requests>=2.9.1
 werkzeug
 gevent-websocket
 har2warc>=1.0.4
-fakeredis
+fakeredis<1.0
 apispec<1.0
 

--- a/webrecorder/test/test_lists_anon_user.py
+++ b/webrecorder/test/test_lists_anon_user.py
@@ -471,7 +471,7 @@ class TestListsAnonUserAPI(FullStackTests):
                                      params=bookmarks)
 
 
-        assert res.json['list']
+        assert res.json['success'] == True
 
     def test_multiple_bookmarks_for_page(self):
         res = self._add_bookmark('1003', title='An Example 2', url='http://example.com/испытание/test',

--- a/webrecorder/webrecorder/listscontroller.py
+++ b/webrecorder/webrecorder/listscontroller.py
@@ -140,11 +140,9 @@ class ListsController(BaseController):
 
             bookmark_list = request.json
 
-            for bookmark_data in bookmark_list:
-                bookmark = blist.create_bookmark(bookmark_data)
+            blist.add_bookmarks(bookmark_list)
 
-            blist.mark_updated()
-            return {'list': blist.serialize()}
+            return {'success': True}
 
         @self.app.get('/api/v1/list/<list_id>/bookmarks')
         @self.api(query=['user', 'coll'],

--- a/webrecorder/webrecorder/models/stats.py
+++ b/webrecorder/webrecorder/models/stats.py
@@ -158,14 +158,14 @@ class Stats(object):
         self.redis.hincrby(self.UPLOADS_COUNT_KEY, today, 1)
         self.redis.hincrby(self.UPLOADS_SIZE_KEY, today, size)
 
-    def incr_bookmark_add(self):
-        self.redis.hincrby(self.BOOKMARK_ADD_KEY, today_str(), 1)
+    def incr_bookmark_add(self, num=1):
+        self.redis.hincrby(self.BOOKMARK_ADD_KEY, today_str(), num)
 
-    def incr_bookmark_mod(self):
-        self.redis.hincrby(self.BOOKMARK_MOD_KEY, today_str(), 1)
+    def incr_bookmark_mod(self, num=1):
+        self.redis.hincrby(self.BOOKMARK_MOD_KEY, today_str(), num)
 
-    def incr_bookmark_del(self):
-        self.redis.hincrby(self.BOOKMARK_DEL_KEY, today_str(), 1)
+    def incr_bookmark_del(self, num=1):
+        self.redis.hincrby(self.BOOKMARK_DEL_KEY, today_str(), num)
 
     def incr_replay(self, size, username):
         if username.startswith(self.TEMP_PREFIX):

--- a/webrecorder/webrecorder/standalone/hooks/hook-gevent.py
+++ b/webrecorder/webrecorder/standalone/hooks/hook-gevent.py
@@ -10,6 +10,8 @@ hiddenimports = [
         'gevent.__semaphore',
         'gevent.__tracer',
         'gevent.__waiter',
+        'gevent._abstract_linkable',
+        'gevent.__abstract_linkable',
         'gevent._event',
         'gevent._greenlet',
         'gevent._local',


### PR DESCRIPTION
- add add_bookmarks() function in BookmarkList
- add ordered in one zadd
- add bookmark data in one hmset
- page-to-bookmarks cache: simplify, avoid updating directly, just remove cache when bookmarks added/removed