### PR TITLE
Commit/Download IO Fixes

### DIFF
--- a/webrecorder/apps/rec.ini
+++ b/webrecorder/apps/rec.ini
@@ -19,4 +19,4 @@ mule = ./webrecorder/rec/tempchecker.py
 mule = ./webrecorder/rec/storagecommitter.py
 
 wsgi = webrecorder.rec.app
-
+disable-logging = true

--- a/webrecorder/webrecorder/rec/main.py
+++ b/webrecorder/webrecorder/rec/main.py
@@ -6,7 +6,7 @@ from webrecorder.rec.webrecrecorder import WebRecRecorder
 
 # =============================================================================
 def init():
-    init_logging()
+    init_logging(debug=True)
 
     config = load_wr_config()
 

--- a/webrecorder/webrecorder/rec/storage/s3.py
+++ b/webrecorder/webrecorder/rec/storage/s3.py
@@ -1,9 +1,12 @@
 import boto3
 import os
+import logging
 
 from six.moves.urllib.parse import urlsplit, quote_plus
 
 from webrecorder.rec.storage.base import BaseStorage
+
+logger = logging.getLogger('wr.io')
 
 
 # ============================================================================
@@ -60,7 +63,6 @@ class S3Storage(BaseStorage):
 
 
         except Exception as e:
-            print(e)
             return False
 
     def get_client_url(self, target_url):
@@ -85,16 +87,15 @@ class S3Storage(BaseStorage):
         s3_url = self._get_s3_url(target_url)
 
         try:
-            print('Uploading {0} -> {1}'.format(full_filename, s3_url))
-            with open(full_filename, 'rb') as fh:
-                self.s3.put_object(Bucket=self.bucket_name,
-                                   Key=target_url,
-                                   Body=fh)
+            logger.debug('S3: Uploading {0} -> {1}'.format(full_filename, s3_url))
+            self.s3.upload_file(full_filename,
+                                Bucket=self.bucket_name,
+                                Key=target_url)
 
             return True
         except Exception as e:
-            print(e)
-            print('Failed to Upload to {0}'.format(s3_url))
+            logger.debug(str(e))
+            logger.debug('S3: Failed to Upload to {0}'.format(s3_url))
             return False
 
     def client_url_to_target_url(self, client_url):
@@ -118,12 +119,12 @@ class S3Storage(BaseStorage):
         :returns: whether successful or not
         :rtype: bool
         """
-        print('Deleting Remote', client_url)
+        logger.debug('S3: Deleting Remote', client_url)
 
         try:
             resp = self.s3.delete_object(Bucket=self.bucket_name,
                                          Key=target_url)
             return True
         except Exception as e:
-            print(e)
+            logger.debug(str(e))
             return False

--- a/webrecorder/webrecorder/rec/storagecommitter.py
+++ b/webrecorder/webrecorder/rec/storagecommitter.py
@@ -4,6 +4,9 @@ import redis
 from webrecorder.models.recording import Recording
 from webrecorder.models.base import BaseAccess
 
+import logging
+logger = logging.getLogger('wr.io')
+
 
 # ============================================================================
 class StorageCommitter(object):
@@ -14,8 +17,8 @@ class StorageCommitter(object):
 
         self.all_cdxj_templ = Recording.CDXJ_KEY.format(rec='*')
 
-        print('Storage Committer Started')
-        print('Storage Root: ' + os.environ['STORAGE_ROOT'])
+        logger.info('Storage Committer Started')
+        logger.info('Storage Root: ' + os.environ['STORAGE_ROOT'])
 
     def __call__(self):
         for cdxj_key in self.redis.scan_iter(self.all_cdxj_templ):

--- a/webrecorder/webrecorder/rec/worker.py
+++ b/webrecorder/webrecorder/rec/worker.py
@@ -4,6 +4,9 @@ import os
 
 from webrecorder.utils import load_wr_config
 
+import logging
+logger = logging.getLogger('wr.io')
+
 
 # ============================================================================
 class Worker(object):
@@ -11,7 +14,7 @@ class Worker(object):
         self._running = True
 
         self.sleep_secs = int(os.environ.get('TEMP_SLEEP_CHECK', 30))
-        print('Running {0} every {1}'.format(worker_cls.__name__, self.sleep_secs))
+        logger.info('Worker: Running {0} every {1}'.format(worker_cls.__name__, self.sleep_secs))
 
         config = load_wr_config()
 

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -17,9 +17,10 @@ def init_logging(debug=False):
                         level=logging.WARNING if not debug else logging.DEBUG)
 
     # set boto log to error
-    boto_log = logging.getLogger('boto')
-    if boto_log:
-        boto_log.setLevel(logging.ERROR)
+    import boto3
+    logging.getLogger('boto3').setLevel(logging.ERROR)
+    logging.getLogger('botocore').setLevel(logging.ERROR)
+    logging.getLogger('s3transfer').setLevel(logging.ERROR)
 
     tld_log = logging.getLogger('tldextract')
     if tld_log:

--- a/webrecorder/webrecorder/utils.py
+++ b/webrecorder/webrecorder/utils.py
@@ -119,8 +119,8 @@ def spawn_once(*args, **kwargs):
 
 # ============================================================================
 @contextmanager
-def redis_pipeline(redis_obj):
-    p = redis_obj.pipeline(transaction=False)
+def redis_pipeline(redis_obj, transaction=False):
+    p = redis_obj.pipeline(transaction=transaction)
     yield p
     p.execute()
 


### PR DESCRIPTION
- Making S3 commit, recording commit, cdxj download more robust
- Ensure temp lock keys always expire
- Better logging: log all file transfer ops, disable request logging for recorder