### PR TITLE
Serve static files in proxy mode directly

### DIFF
--- a/webrecorder/test/test_player_proxy.py
+++ b/webrecorder/test/test_player_proxy.py
@@ -188,10 +188,18 @@ class TestPlayer(BaseTestPlayer):
         assert res.status_code == 200
         assert 'wombat' in res.text
 
-        res = self.session.get('http://webrecorder.proxy/static_cors/bundle/proxy.js', proxies=self.proxies)
+        assert 'Access-Control-Allow-Origin' not in res.headers
+
+    def test_proxy_static_cors(self):
+        res = self.session.get('http://webrecorder.proxy/static_cors/bundle/proxy.js', proxies=self.proxies,
+                               headers={'Origin': 'http://example.com/'})
+
         assert res.status_code == 200
         assert 'wombat' in res.text
 
+        assert res.headers['Access-Control-Allow-Origin'] == '*'
+
+    def test_proxy_static_err(self):
         res = self.session.get('http://webrecorder.proxy/static_cors/bundle/not-found-x', proxies=self.proxies)
         assert res.status_code == 404
         assert 'No such page' in res.text

--- a/webrecorder/test/test_player_proxy.py
+++ b/webrecorder/test/test_player_proxy.py
@@ -183,6 +183,19 @@ class TestPlayer(BaseTestPlayer):
         assert res.url == 'http://example.com/'
         assert res.headers['Memento-Datetime'] == 'Wed, 01 Jan 2014 00:00:00 GMT'
 
+    def test_proxy_static(self):
+        res = self.session.get('http://webrecorder.proxy/static/bundle/proxy.js', proxies=self.proxies)
+        assert res.status_code == 200
+        assert 'wombat' in res.text
+
+        res = self.session.get('http://webrecorder.proxy/static_cors/bundle/proxy.js', proxies=self.proxies)
+        assert res.status_code == 200
+        assert 'wombat' in res.text
+
+        res = self.session.get('http://webrecorder.proxy/static_cors/bundle/not-found-x', proxies=self.proxies)
+        assert res.status_code == 404
+        assert 'No such page' in res.text
+
     def test_ws_init(self):
         ws = websocket.WebSocket()
         ws.connect('ws://localhost:{0}/_client_ws_cont'.format(self.app_port))

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -1,4 +1,4 @@
-from bottle import debug, request, response, static_file, redirect, BaseRequest
+from bottle import debug, request, response, redirect, BaseRequest
 
 import logging
 import json
@@ -377,7 +377,14 @@ class MainController(BaseController):
 
         @self.bottle_app.route(['/static/<path:path>', '/static_cors/<path:path>'])
         def static_files(path):
-            res = static_file(path, root=self.static_root)
+            filename = path.split('?', 1)[0]
+            filename = os.path.join(self.static_root, filename)
+            if not os.path.isfile(filename):
+                response.status = 404
+                return
+
+            with open(filename, 'rt') as fh:
+                res = fh.read()
 
             if 'HTTP_ORIGIN' in request.environ:
                 self.set_options_headers(None, None, res)
@@ -421,7 +428,7 @@ class MainController(BaseController):
                 return
 
             # return html error view for any content errors
-            if self.is_content_request():
+            if self.is_content_request() or 'wsgiprox.proxy_host' in request.environ:
                 if self.content_error_redirect:
                     err_context = {'status': out.status_code,
                                    'error': out.body

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -387,7 +387,7 @@ class MainController(BaseController):
                 res = fh.read()
 
             if 'HTTP_ORIGIN' in request.environ:
-                self.set_options_headers(None, None, res)
+                self.set_options_headers(None, None)
 
             return res
 


### PR DESCRIPTION
Serve static files by buffering directly to avoid possible unclosed file handle warnings.
Only affects CORS-requiring static files, others served by uwsgi and nginx.

