### PR TITLE
Improved Rate limit Message

### DIFF
--- a/webrecorder/test/test_rate_limits.py
+++ b/webrecorder/test/test_rate_limits.py
@@ -121,6 +121,9 @@ class TestRateLimits(FullStackTests):
 
         res = res.follow(headers=headers, status=402)
 
+        assert 'Rate Limit Exceeded' in res.text
+        assert 'network traffic quota' in res.text
+
         time.sleep(0.0)
         keys = self.redis.keys('ipr:10.0.0*')
 

--- a/webrecorder/test/test_record_limits.py
+++ b/webrecorder/test/test_record_limits.py
@@ -102,6 +102,8 @@ class TestRecordLimits(FullStackTests):
         res.charset = 'utf-8'
         assert res.status_code == 402
 
+        assert 'out of space in your temporary' in res.text
+
     def test_record_again(self):
         warc_file, warc_size, user_key, curr_size = self._get_info()
 

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -250,7 +250,7 @@ class MainController(BaseController):
 
         @contextfunction
         def is_anon(context):
-            return self.access.is_anon(get_user(context))
+            return self.access.session_user.is_anon()
 
         def get_announce_list():
             announce_list = os.environ.get('ANNOUNCE_MAILING_LIST', False)

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -428,7 +428,7 @@ class MainController(BaseController):
                 return
 
             # return html error view for any content errors
-            if self.is_content_request() or 'wsgiprox.proxy_host' in request.environ:
+            if self.is_content_request() or out.status_code == 402 or 'wsgiprox.proxy_host' in request.environ:
                 if self.content_error_redirect:
                     err_context = {'status': out.status_code,
                                    'error': out.body

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -214,10 +214,10 @@ class MainController(BaseController):
             return self.browser_mgr.get_browsers()
 
         def get_app_host():
-            return self.app_host
+            return self.app_host or 'http://localhost:8089'
 
         def get_content_host():
-            return self.content_host
+            return self.content_host or 'http://localhost:8092'
 
         def get_num_collections():
             count = self.access.session_user.num_total_collections()

--- a/webrecorder/webrecorder/templates/error.html
+++ b/webrecorder/webrecorder/templates/error.html
@@ -32,16 +32,15 @@
 {% else %}
       <div class="panel-heading">
           <span class="glyphicon glyphicon-exclamation-sign" aria-hidden="true"></span>
-          <strong class="left-buffer">There's been an error</strong>
+          <strong class="left-buffer">{{ "Rate Limit Exceeded" if err.body == "rate_limit_exceeded" else "There's been an error"}}</strong>
       </div>
       <div class="panel-body">
         {% if err.status_code == 404 %}
         No such page or content is not accessible.
-        {% elif err.status_code == 402 and err.body == 'Rate Limit' %}
-        <p>Sorry, you have exceeded the rate limit for recording.</p>
-        <p><b>Please note:</b> Webrecorder is a <a href="/_faq">tool for high-fidelity web archiving</a>. If you are using Webrecorder for any other reason, this is not supported and you may be violating our <a href="/_policies">Terms of Service</a>.</p>
-
-        <p>If you think this message is in error, you can <a href="mailto:support@webrecorder.io" target="_parent" >let us know</a> how you are using Webrecorder.</p>
+        {% elif err.status_code == 402 and err.body == 'rate_limit_exceeded' %}
+        <p>You have reached your network traffic quota.</p>
+        <p>Webrecorder is a service for <a href="/_faq">archiving web resources</a> and any other use, such as video streaming or trying to get around local access restrictions, is not supported.</p>
+        <p>If you are using Webrecorder within our <a href="/_policies">Terms of Service</a> and this limit is hindering a web archiving project you are working on, please send a message to <a href="mailto:support@webrecorder.io">support@webrecorder.io</a> with some details about your project and a request to to raise your data limit.</p>
         {% else %}
         {{ err.body }}
         {% endif %}

--- a/webrecorder/webrecorder/templates/error.html
+++ b/webrecorder/webrecorder/templates/error.html
@@ -2,6 +2,7 @@
 
 {% block head %}
 {{ super() }}
+<base target="_parent">
 <script>
 
     $(function() {
@@ -39,8 +40,8 @@
         No such page or content is not accessible.
         {% elif err.status_code == 402 and err.body == 'rate_limit_exceeded' %}
         <p>You have reached your network traffic quota.</p>
-        <p>Webrecorder is a service for <a href="/_faq">archiving web resources</a> and any other use, such as video streaming or trying to get around local access restrictions, is not supported.</p>
-        <p>If you are using Webrecorder within our <a href="/_policies">terms and policies</a> and this limit is hindering a web archiving project you are working on, please send a message to <a href="mailto:support@webrecorder.io">support@webrecorder.io</a> with some details about your project and a request to raise your data limit.</p>
+        <p>Webrecorder is a service for <a href="{{ get_app_host() }}/_faq">archiving web resources</a> and any other use, such as video streaming or trying to get around local access restrictions, is not supported.</p>
+        <p>If you are using Webrecorder within our <a href="{{ get_app_host() }}/_policies">terms and policies</a> and this limit is hindering a web archiving project you are working on, please send a message to <a href="mailto:support@webrecorder.io">support@webrecorder.io</a> with some details about your project and a request to raise your data limit.</p>
         {% else %}
         {{ err.body }}
         {% endif %}

--- a/webrecorder/webrecorder/templates/error.html
+++ b/webrecorder/webrecorder/templates/error.html
@@ -40,7 +40,7 @@
         {% elif err.status_code == 402 and err.body == 'rate_limit_exceeded' %}
         <p>You have reached your network traffic quota.</p>
         <p>Webrecorder is a service for <a href="/_faq">archiving web resources</a> and any other use, such as video streaming or trying to get around local access restrictions, is not supported.</p>
-        <p>If you are using Webrecorder within our <a href="/_policies">Terms of Service</a> and this limit is hindering a web archiving project you are working on, please send a message to <a href="mailto:support@webrecorder.io">support@webrecorder.io</a> with some details about your project and a request to to raise your data limit.</p>
+        <p>If you are using Webrecorder within our <a href="/_policies">terms and policies</a> and this limit is hindering a web archiving project you are working on, please send a message to <a href="mailto:support@webrecorder.io">support@webrecorder.io</a> with some details about your project and a request to raise your data limit.</p>
         {% else %}
         {{ err.body }}
         {% endif %}

--- a/webrecorder/webrecorder/templates/error.html
+++ b/webrecorder/webrecorder/templates/error.html
@@ -14,7 +14,7 @@
 {% endblock %}
 
 {% block content %}
-<div class="container col-md-4 col-md-offset-4 top-buffer-lg">
+<div class="container col-md-8 col-md-offset-2 top-buffer-lg">
     <div class="panel panel-danger">
 {% if is_temp %}
       <div class="panel-heading">

--- a/webrecorder/webrecorder/templates/out_of_space_message.html
+++ b/webrecorder/webrecorder/templates/out_of_space_message.html
@@ -3,7 +3,7 @@
     {% if is_anon() %}
         {% set message = "
 
-        <p><strong>Your are out of space in your temporary collection.</strong>  This means you can't record anything right now.</p>
+        <p><strong>You are out of space in your temporary collection.</strong>  This means you can't record anything right now.</p>
 
         <p>To be able to record again, you can:</p>
 


### PR DESCRIPTION
Updated rate limit message, ensure its being displayed for `rate_limit_exceeded` error
Also ensure out of space message is working.
Add rate limit and out of space text to unit tests, always display template for 402 errors.