### PR TITLE
Option to configure session redirect host

### DIFF
--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -53,6 +53,7 @@ class ContentController(BaseController, RewriterApp):
         self.replay_host = os.environ.get('WARCSERVER_PROXY_HOST')
         if not self.replay_host:
             self.replay_host = self.live_host
+        self.session_redirect_host = os.environ.get('SESSION_REDIRECT_HOST')
 
         self.wam_loader = WAMLoader()
         self._init_client_archive_info()
@@ -576,7 +577,7 @@ class ContentController(BaseController, RewriterApp):
     def redir_set_session(self):
         full_path = request.environ['SCRIPT_NAME'] + request.environ['PATH_INFO']
         full_path = self.add_query(full_path)
-        self.redir_host(None, '/_set_session?path=' + quote(full_path))
+        self.redir_host(self.session_redirect_host, '/_set_session?path=' + quote(full_path))
 
     def _create_new_rec(self, collection, title, mode, desc=''):
         #rec_name = self.sanitize_title(title) if title else ''


### PR DESCRIPTION
@ikreymer has been collaborating with the [Perma.cc](https://github.com/harvard-lil/perma) team to build a version of Perma that uses the Webrecorder API for playback of web archives, and eventually, for the creation of new ones.

Perma creates collections and uploads already-existing warcs to a custom deployment of Webrecorder on behalf of visitors, and then serves the visitor a page containing an `iframe` responsible for playback. If the visitor requires a Webrecorder session cookie in order to view the playback, Webrecorder redirects the iframe in order to obtain one:
```
    # webrecorder/webrecorder/contentcontroller.py
    def redir_set_session(self):
        full_path = request.environ['SCRIPT_NAME'] + request.environ['PATH_INFO']
        full_path = self.add_query(full_path)
        self.redir_host(None, '/_set_session?path=' + quote(full_path))
```
While this works for current production Webrecorder, Perma needs the `iframe` to redirect to a Perma-hosted url that Ilya set up, https://github.com/harvard-lil/perma/blob/develop/perma_web/perma/views/common.py#L223, which passes the user the cookie for the correct Webrecorder session.

This PR adds a new, optional configuration variable, `SESSION_REDIRECT_HOST`. If absent (default), Webrecorder is unchanged: it behaves as it does today. If present, it redirects to the configured host to obtain session cookies.

This will be helpful not only for Perma's particular use case, but for any situation in which `APP_HOST` and `CONTENT_HOST` are being served by different web servers, for instance, if Webrecorder is scaled to run across a number of nodes (in which case `SESSION_REDIRECT_HOST` = `APP_HOST`)