### PR TITLE
Mark the collection passed to `ensure_login` active

### DIFF
--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -761,7 +761,7 @@ class Collection(PagesMixin, RedisUniqueComponent):
     def sync_coll_index(self, exists=False, do_async=False):
         coll_cdxj_key = self.COLL_CDXJ_KEY.format(coll=self.my_id)
         if exists != self.redis.exists(coll_cdxj_key):
-            self.reset_cdxj_ttl()
+            self.reset_cdxj_ttl(coll_cdxj_key)
             return
 
         cdxj_keys = self._get_rec_keys(Recording.CDXJ_KEY)

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -769,7 +769,7 @@ class Collection(PagesMixin, RedisUniqueComponent):
             return
 
         self.redis.zunionstore(coll_cdxj_key, cdxj_keys)
-        self.reset_cdxj_ttl()
+        self.reset_cdxj_ttl(coll_cdxj_key)
 
         ges = []
         for cdxj_key in cdxj_keys:

--- a/webrecorder/webrecorder/models/collection.py
+++ b/webrecorder/webrecorder/models/collection.py
@@ -661,7 +661,6 @@ class Collection(PagesMixin, RedisUniqueComponent):
             except:
                 pass
 
-        #self.redis.expire(coll_cdxj_key, self.COLL_CDXJ_TTL)
         return count
 
     def add_warcs(self, warc_map):
@@ -751,11 +750,18 @@ class Collection(PagesMixin, RedisUniqueComponent):
         coll_cdxj_key = self.COLL_CDXJ_KEY.format(coll=self.my_id)
         return self.redis.exists(coll_cdxj_key)
 
+    def reset_cdxj_ttl(self, key=None):
+        if not key:
+            key = self.COLL_CDXJ_KEY.format(coll=self.my_id)
+        if self.COLL_CDXJ_TTL > 0:
+            self.redis.expire(key, self.COLL_CDXJ_TTL)
+            return True
+        return False
+
     def sync_coll_index(self, exists=False, do_async=False):
         coll_cdxj_key = self.COLL_CDXJ_KEY.format(coll=self.my_id)
         if exists != self.redis.exists(coll_cdxj_key):
-            if self.COLL_CDXJ_TTL > 0:
-                self.redis.expire(coll_cdxj_key, self.COLL_CDXJ_TTL)
+            self.reset_cdxj_ttl()
             return
 
         cdxj_keys = self._get_rec_keys(Recording.CDXJ_KEY)
@@ -763,8 +769,7 @@ class Collection(PagesMixin, RedisUniqueComponent):
             return
 
         self.redis.zunionstore(coll_cdxj_key, cdxj_keys)
-        if self.COLL_CDXJ_TTL > 0:
-            self.redis.expire(coll_cdxj_key, self.COLL_CDXJ_TTL)
+        self.reset_cdxj_ttl()
 
         ges = []
         for cdxj_key in cdxj_keys:
@@ -813,8 +818,7 @@ class Collection(PagesMixin, RedisUniqueComponent):
                     if fh:
                         fh.close()
 
-            if self.COLL_CDXJ_TTL > 0:
-                self.redis.expire(output_key, self.COLL_CDXJ_TTL)
+            self.reset_cdxj_ttl(output_key)
 
         except Exception as e:
             logger.error('CDX Sync: Error downloading cache: ' + str(e))

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -74,6 +74,7 @@ class UserController(BaseController):
             coll_empty = True
             coll_created = True
         else:
+            collection.reset_cdxj_ttl()
             coll_empty = collection.size == 0
             coll_created = False
 


### PR DESCRIPTION
The new [`ensure_login` API route](https://github.com/webrecorder/webrecorder/blob/master/webrecorder/webrecorder/usercontroller.py#L40), if passed a collection `title`, ensures that the collection exists. However, it does not currently affect the scheduled deletion of that collection. So, collections belonging to anonymous users and external collections belonging to registered users can be deleted by `tempchecker.py` at any time, including milliseconds after `ensure_login` is called.

To prevent that unexpected behavior for registered users, this PR causes `ensure_login` to reset the TTL of the passed-in collection, using a new convenience method on the `Collection` model.

The anonymous case is not addressed by this PR.