### PR TITLE
docker-compose suggestions

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
     app:
         build: ./webrecorder
-        command: uwsgi /code/apps/apiapp.ini
+        command: uwsgi --need-app /code/apps/apiapp.ini
 
         env_file:
             - ./wr.env
@@ -59,7 +59,7 @@ services:
 
     recorder:
         build: ./webrecorder
-        command: uwsgi /code/apps/rec.ini
+        command: uwsgi --need-app /code/apps/rec.ini
 
         env_file:
             - ./wr.env
@@ -74,7 +74,7 @@ services:
 
     warcserver:
         build: ./webrecorder
-        command: uwsgi /code/apps/load.ini
+        command: uwsgi --need-app /code/apps/load.ini
 
         env_file:
             - ./wr.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,6 @@ services:
 
         volumes:
             - ./webrecorder/:/code/
-            - ./webrecorder/proxy-certs:/code/proxy-certs
             - ./data:/data
 
         networks:


### PR DESCRIPTION
Two tiny suggested tweaks to docker-compose based on the Perma team's experience so far:

We have found it convenient to run with uWSGI with the [`--need-app` flag](https://uwsgi-docs.readthedocs.io/en/latest/Options.html?highlight=%22need-app%22#need-app) so that the whole container crashes if the python application fails to load, rather than staying up but serving nothing. It's hard for me to imagine a situation in which it's anything-but-misleading for uWSGI to be running without an app; you may find this convenient as well!

We also noticed that the `proxy-certs` bind mount declaration is redundant with `./webrecorder/:/code/`. Since its presence has no effect, no particular reason to remove it from the file, except for documentation purposes. When we were just getting started, we thought this meant we had to create some certs before running, so they could be mounted in and used by the app.