### PR TITLE
fix logged in session expiration from content domain usage:

### DIFF
--- a/webrecorder/test/test_patch.py
+++ b/webrecorder/test/test_patch.py
@@ -41,7 +41,7 @@ class TestPatchContent(FullStackTests):
         assert len(os.listdir(anon_dir)) == 1
 
     def test_patch_js(self):
-        res = self.testapp.get('/{user}/temp/new-patch/patch/mp_/https://www.iana.org/_js/2013.1/jquery.js'.format(user=self.anon_user))
+        res = self.testapp.get('/{user}/temp/new-patch/patch/js_/https://httpbin.org/base64/ZnVuY3Rpb24gdGVzdCgpIHsNCiAgdGVzdCgiYWJjIik7DQp9'.format(user=self.anon_user))
         assert 'let window' in res.text
 
     def test_patch_content_at_timestamp(self):

--- a/webrecorder/webrecorder/config/wr.yaml
+++ b/webrecorder/webrecorder/config/wr.yaml
@@ -11,7 +11,7 @@ session.durations:
 
     restricted:
         total: 5400
-        extend: 0
+        extend: 3600
 
 # session settings
 session.secret: $SECRET_KEY

--- a/webrecorder/webrecorder/session.py
+++ b/webrecorder/webrecorder/session.py
@@ -395,10 +395,10 @@ class RedisSessionMiddleware(CookieGuard):
                     self.track_long_term(session, pi)
 
                 # set redis duration
-                if not session.is_restricted:
+                if session.curr_role != 'anon':
                     pi.expire(session.key, duration)
 
-        elif set_cookie and not session.is_restricted:
+        elif set_cookie and session.curr_role != 'anon':
             # extend redis duration if extending cookie!
             self.redis.expire(session.key, duration)
 


### PR DESCRIPTION
ensure that restricted, non-anonymous session can be extended if ttl < extend time
tests: fix patch test, use httpbin instead of remote site.

Previously, 'restricted' sessions did not extend the internal session time, meaning that browsing via content domain (w/o any api calls) could still cause session to expire. This change makes it so only anonymous sessions (which are also restricted) do not extend the session, non-anonymous sessions should extend expiry (and cookie) when used.