### PR TITLE
Quote variables to better support spaces, etc.

### DIFF
--- a/init-default.sh
+++ b/init-default.sh
@@ -10,17 +10,17 @@ if [ -e "$target" ]; then
    exit 1
 fi
 
-cp $sample $target
+cp "$sample" "$target"
 
 function set_key {
     key=$(python -c "import os; import base64; print(base64.b32encode(os.urandom(75)))")
-    sed -i'' -e "s/$1=.*/$1=$key/g" $target
+    sed -i'' -e "s/$1=.*/$1=$key/g" "$target"
 }
 
 set_key "SECRET_KEY"
 set_key "ENCRYPT_KEY"
 set_key "VALIDATE_KEY"
 
-mkdir $CURR_DIR/data
-mkdir $CURR_DIR/data/warcs/
+mkdir "$CURR_DIR/data"
+mkdir "$CURR_DIR/data/warcs/"
 


### PR DESCRIPTION
Double quote to prevent globbing and word splitting