### PR TITLE
Tempchecker logging

### DIFF
--- a/webrecorder/webrecorder/rec/main.py
+++ b/webrecorder/webrecorder/rec/main.py
@@ -1,12 +1,15 @@
 from gevent import monkey; monkey.patch_all()
 
+import os
+from ast import literal_eval
+
 from webrecorder.utils import load_wr_config, init_logging, spawn_once
 from webrecorder.rec.webrecrecorder import WebRecRecorder
 
 
 # =============================================================================
 def init():
-    init_logging(debug=True)
+    init_logging(debug=literal_eval(os.environ.get('WR_DEBUG', 'True')))
 
     config = load_wr_config()
 

--- a/webrecorder/webrecorder/rec/tempchecker.py
+++ b/webrecorder/webrecorder/rec/tempchecker.py
@@ -197,8 +197,7 @@ class TempChecker(object):
                     logger.debug('TempChecker: Delete Expired External Coll: ' + collection.my_id)
                     user.remove_collection(collection, delete=True)
             except Exception:
-                import traceback
-                traceback.print_exc()
+                logger.exception('TempChecker: Exception Removing External Coll: ' + collection.my_id)
 
 
 # =============================================================================

--- a/webrecorder/webrecorder/rec/tempchecker.py
+++ b/webrecorder/webrecorder/rec/tempchecker.py
@@ -182,17 +182,17 @@ class TempChecker(object):
         all_ext_templ = Collection.EXTERNAL_KEY.format(coll='*')
 
         for ext_key in self.data_redis.scan_iter(all_ext_templ):
+            _, coll, _2 = ext_key.split(':', 2)
+
+            collection = Collection(my_id=coll,
+                                    redis=self.data_redis,
+                                    access=BaseAccess())
+
+            user = collection.get_owner()
+            if not user or user.is_anon():
+                continue
+
             try:
-                _, coll, _2 = ext_key.split(':', 2)
-
-                collection = Collection(my_id=coll,
-                                        redis=self.data_redis,
-                                        access=BaseAccess())
-
-                user = collection.get_owner()
-                if not user or user.is_anon():
-                    continue
-
                 if not collection.has_cdxj():
                     logger.debug('TempChecker: Delete Expired External Coll: ' + collection.my_id)
                     user.remove_collection(collection, delete=True)

--- a/webrecorder/webrecorder/rec/tempchecker.py
+++ b/webrecorder/webrecorder/rec/tempchecker.py
@@ -194,7 +194,7 @@ class TempChecker(object):
                     continue
 
                 if not collection.has_cdxj():
-                    logger.debug('TempChecker: Delete Expired External Coll: ' + collection.name)
+                    logger.debug('TempChecker: Delete Expired External Coll: ' + collection.my_id)
                     user.remove_collection(collection, delete=True)
             except Exception:
                 import traceback


### PR DESCRIPTION
Perma has noticed a lot of stack traces being printed by [line 197 of the tempchecker](https://github.com/webrecorder/webrecorder/blob/master/webrecorder/webrecorder/rec/tempchecker.py#L197)
```
    May 30 13:25:38 ip-172-31-60-73 docker-compose[651]: recorder_1    | Traceback (most recent call last):
    May 30 13:25:38 ip-172-31-60-73 docker-compose[651]: recorder_1    |   File "./webrecorder/rec/tempchecker.py", line 197, in delete_expired_external
    May 30 13:25:38 ip-172-31-60-73 docker-compose[651]: recorder_1    |     logger.debug('TempChecker: Delete Expired External Coll: ' + collection.name)
    May 30 13:25:38 ip-172-31-60-73 docker-compose[651]: recorder_1    | TypeError: can only concatenate str (not "NoneType") to str
```

This PR:
- addresses the reason for the underlying exception (the attempt to access [`collection.name`](https://github.com/webrecorder/webrecorder/blob/master/webrecorder/webrecorder/models/base.py#L74) in the debugging message attempts to load data from redis... and sometimes another tempchecker mule has already arranged for that info to be removed from redis) by logging `collection.my_id` instead of `collection.name`, consistent with the other logging that results from the tempchecker
- switches from `traceback.print_exc()` to `logger.exception`, to facilitate log filtering/aggregation/handing etc.
- first pass at narrowing the `try/except` so as to exclude lines of code that aren't expected to raise exceptions
- adds the option to run the recorder container (and thus the tempchecker) with debug=False via an environment variable instead of [hard coding debug=True](https://github.com/webrecorder/webrecorder/blob/c402c0b1dea1ef73390145556eea16be66661fc3/webrecorder/webrecorder/rec/main.py#L9), to make it possible to silence the helpful-but-chatty debug-level logs in production.