### PR TITLE
filter remote browsers dropdown:

### DIFF
--- a/frontend/src/components/controls/RemoteBrowserSelectUI/index.js
+++ b/frontend/src/components/controls/RemoteBrowserSelectUI/index.js
@@ -9,6 +9,7 @@ import { RemoteBrowserOption } from 'components/controls';
 
 import 'shared/scss/dropdown.scss';
 
+import { filterBrowsers } from 'config';
 
 class RemoteBrowserSelectUI extends PureComponent {
   static contextTypes = {
@@ -91,6 +92,19 @@ class RemoteBrowserSelectUI extends PureComponent {
 
     const activeBrowserEle = browsers ? browsers.find(b => b.get('id') === instanceContext) : null;
 
+    let showBrowsers = [];
+
+    if (browsers && filterBrowsers) {
+      filterBrowsers.forEach((id) => {
+        const browser = browsers.get(id);
+        if (browser) {
+          showBrowsers.push(browser);
+        }
+      });
+    } else if (browsers) {
+      showBrowsers = browsers.valueSeq();
+    }
+
     const btn = activeBrowserEle ?
       (
         <span className="btn-content">
@@ -117,8 +131,8 @@ class RemoteBrowserSelectUI extends PureComponent {
           { loading &&
             <div>loading options..</div>
           }
-          { loaded && browsers &&
-              browsers.valueSeq().map(browser => <RemoteBrowserOption browser={browser} key={browser.get('id') ? browser.get('id') : 'native'} selectBrowser={this.selectBrowser} isActive={instanceContext === browser.get('id')} />)
+          { loaded && showBrowsers &&
+              showBrowsers.map(browser => <RemoteBrowserOption browser={browser} key={browser.get('id') ? browser.get('id') : 'native'} selectBrowser={this.selectBrowser} isActive={instanceContext === browser.get('id')} />)
           }
           {
             <RemoteBrowserOption browser={fromJS({ id: null, name: 'Use Current Browser' })} selectBrowser={this.selectBrowser} isActive={instanceContext === null} />

--- a/frontend/src/config.js
+++ b/frontend/src/config.js
@@ -76,6 +76,7 @@ export default Object.assign({
     PAGE_ITEM: 'pageItem',
     TH: 'tableHeader'
   },
+  filterBrowsers: ['chrome:76', 'firefox:68', 'firefox:49'],
   guestSessionTimeout: '90mins',
   homepageAnnouncement: '',
   internalApiHost: process.env.INTERNAL_HOST,

--- a/install-browsers.sh
+++ b/install-browsers.sh
@@ -1,8 +1,10 @@
 #!/bin/sh
 
-# This script pulls all of the available remote browsers, and the remote desktop system
+# This script pulls the available remote browsers, and the remote desktop system
 # The remote desktop system containers are required for any browser
 # Browsers can be installed individually if installing all of the browsers is not desired.
+
+# By default, only latest versions of browsers are pulled. Uncomment other versions to include them as well.
 
 # Remote Desktop System and Base Browser (Required for all browsers)
 docker pull oldwebtoday/vnc-webrtc-audio
@@ -10,16 +12,22 @@ docker pull oldwebtoday/base-displayaudio
 docker pull oldwebtoday/base-browser
 
 # For automation (works with chrome 67 and up)
-docker pull oldwebtoday/autobrowser
+docker pull webrecorder/autobrowser
+
+# pull behaviors to ensure latest version
+docker pull webrecorder/behaviors
 
 # Chrome
-docker pull oldwebtoday/chrome:53
-docker pull oldwebtoday/chrome:60
-docker pull oldwebtoday/chrome:67
-docker pull oldwebtoday/chrome:73
+#docker pull oldwebtoday/chrome:53
+#docker pull oldwebtoday/chrome:60
+#docker pull oldwebtoday/chrome:67
+#docker pull oldwebtoday/chrome:73
+docker pull oldwebtoday/chrome:76
 
 # Firefox
+# for java support, include ff 49
 docker pull oldwebtoday/firefox:49
-docker pull oldwebtoday/firefox:56
-docker pull oldwebtoday/firefox:57
+#docker pull oldwebtoday/firefox:56
+#docker pull oldwebtoday/firefox:57
+docker pull oldwebtoday/firefox:68
 


### PR DESCRIPTION
- add config 'filterBrowsers' array to indicate which browsers should be included
- default to chrome:76, firefox:68, firefox:49 (for java)
- update/fix install-browsers.sh with latest chrome and firefox images, disabling pulling older versions