### PR TITLE
WASAPI Open API Spec Documentation

### DIFF
--- a/webrecorder/test/test_api_user_login.py
+++ b/webrecorder/test/test_api_user_login.py
@@ -1,4 +1,6 @@
 from .testutils import FullStackTests
+from webrecorder.apiutils import wr_api_spec
+import json
 
 from mock import patch
 import re
@@ -478,8 +480,25 @@ class TestApiUserLogin(FullStackTests):
         assert res.json['user']['anon'] == True
         assert res.json['user']['num_collections'] == 0
 
-    def test_openapi_spec(self):
-        assert self.testapp.get('/api/v1', status=200).content_type == 'text/yaml'
+    def test_openapi_spec_yaml(self):
+        assert self.testapp.get('/api/v1.yml', status=200).content_type == 'text/yaml'
+
+    def test_openapi_spec_json(self):
+        res = self.testapp.get('/api/v1.json', status=200)
+        assert res.content_type == 'application/json'
+        api_paths = res.json.get('paths')
+
+        web_data = api_paths.get('/api/v1/download/webdata')
+        assert web_data is not None
+
+        get = web_data.get('get')
+        assert get is not None
+        assert len(get.get('parameters')) == 3
+        assert len(get.get('tags')) == 1
+        assert get.get('tags')[0] == 'WASAPI'
+
+        get_responses = get.get('responses', {}).get('200', {})
+        assert json.dumps(get_responses) == json.dumps(wr_api_spec.all_responses['wasapi_list'])
 
     def test_invalid_api(self):
         # unknown api

--- a/webrecorder/test/test_api_user_login.py
+++ b/webrecorder/test/test_api_user_login.py
@@ -495,7 +495,11 @@ class TestApiUserLogin(FullStackTests):
         assert get is not None
         assert len(get.get('parameters')) == 3
         assert len(get.get('tags')) == 1
-        assert get.get('tags')[0] == 'WASAPI'
+        assert 'WASAPI' in get.get('responses').get('200').get('description')
+        assert get.get('tags')[0] == 'Downloads'
+
+        downloads = api_paths.get('/api/v1/download/{user}/{coll}/{filename}')
+        assert 'WARC/1.0' in downloads['get']['responses']['200']['content']['application/warc']['schema']['example']
 
         get_responses = get.get('responses', {}).get('200', {})
         assert json.dumps(get_responses) == json.dumps(wr_api_spec.all_responses['wasapi_list'])

--- a/webrecorder/webrecorder/admincontroller.py
+++ b/webrecorder/webrecorder/admincontroller.py
@@ -643,11 +643,12 @@ class AdminController(BaseController):
             response.content_type = 'application/json'
             return json.dumps(stats)
 
-
         @self.app.post('/api/v1/stats/annotations')
         @self.admin_view
         def stats_annotations():
             return []
+
+        wr_api_spec.set_curr_tag(None)
 
 
 

--- a/webrecorder/webrecorder/apiutils.py
+++ b/webrecorder/webrecorder/apiutils.py
@@ -12,6 +12,9 @@ class WRAPISpec(object):
     RE_URL = re.compile(r'<(?:[^:<>]+:)?([^<>]+)>')
 
     tags = [
+        {'name': 'Downloads',
+         'description': 'Download WARC files API (conforms to WASAPI spec)'},
+
         {'name': 'Auth',
          'description': 'Auth and Login API'},
 
@@ -30,6 +33,12 @@ class WRAPISpec(object):
         {'name': 'Bookmarks',
          'description': 'Bookmarks API'},
 
+        {'name': 'Uploads',
+         'description': 'Upload WARC or HAR files API'},
+
+        {'name': 'Add External Records',
+         'description': 'Add External WARC Records API'},
+
         {'name': 'Browsers',
          'description': 'Browser API'},
 
@@ -47,9 +56,6 @@ class WRAPISpec(object):
 
         {'name': 'Stats',
          'description': 'Stats API'},
-
-        {'name': 'WASAPI',
-         'description': 'Web Archiving Systems API'},
 
         {'name': 'Automation',
          'description': 'Automation API'},
@@ -106,6 +112,7 @@ class WRAPISpec(object):
 
     all_responses = {
         'wasapi_list': {
+            'description': 'WASAPI response for list of WARC files available for download',
             'content': {
                 'application/json': {
                     'schema': {
@@ -130,6 +137,18 @@ class WRAPISpec(object):
                             },
                             'include-extra': {'type': 'boolean'}
                         }
+                    }
+                }
+            }
+        },
+        'wasapi_download': {
+            'description': 'WARC file',
+            'content': {
+                'application/warc': {
+                    'schema': {
+                        'type': 'string',
+                        'format': 'binary',
+                        'example': 'WARC/1.0\r\nWARC-Type: response\r\n...',
                     }
                 }
             }

--- a/webrecorder/webrecorder/autocontroller.py
+++ b/webrecorder/webrecorder/autocontroller.py
@@ -3,11 +3,13 @@ from webrecorder.models.auto import Auto
 from bottle import request, response
 import requests
 import os
+from webrecorder.apiutils import wr_api_spec
 
 
 # ============================================================================
 class AutoController(BaseController):
     def init_routes(self):
+        wr_api_spec.set_curr_tag('Automation')
         # CREATE AUTO
         @self.app.post('/api/v1/auto')
         def create_auto():
@@ -66,6 +68,8 @@ class AutoController(BaseController):
             auto.delete_me()
 
             return {'deleted_id': auto.my_id}
+
+        wr_api_spec.set_curr_tag(None)
 
     def load_user_coll_auto(self, autoid, user=None, coll_name=None):
         user, collection = self.load_user_coll(user=user, coll_name=coll_name)

--- a/webrecorder/webrecorder/behaviormgr.py
+++ b/webrecorder/webrecorder/behaviormgr.py
@@ -1,3 +1,4 @@
+from webrecorder.apiutils import wr_api_spec
 from webrecorder.basecontroller import BaseController
 from bottle import request, static_file, HTTPResponse, response
 import os
@@ -80,6 +81,8 @@ class BehaviorMgr(BaseController):
         return None
 
     def init_routes(self):
+        wr_api_spec.set_curr_tag('Behaviors')
+
         @self.app.get('/api/v1/behavior/info')
         def info_list():
             # for non-desktop proxy mode, proxy to behaviors server
@@ -120,3 +123,5 @@ class BehaviorMgr(BaseController):
 
             res = static_file(behavior['fileName'], root=self.behaviors_data)
             return res
+
+        wr_api_spec.set_curr_tag(None)

--- a/webrecorder/webrecorder/bugreportcontroller.py
+++ b/webrecorder/webrecorder/bugreportcontroller.py
@@ -48,6 +48,8 @@ class BugReportController(BaseController):
             self.do_report(data, useragent)
             return {}
 
+        wr_api_spec.set_curr_tag(None)
+
     def do_report(self, params, ua=''):
         report = {}
         for key in params:

--- a/webrecorder/webrecorder/collscontroller.py
+++ b/webrecorder/webrecorder/collscontroller.py
@@ -272,6 +272,8 @@ class CollsController(BaseController):
             #rec_list = [self.sanitize_title(title) for title in rec_list.split(',')]
             return self.get_collection_info_for_view(user, coll_name)
 
+        wr_api_spec.set_curr_tag(None)
+
     def get_collection_info_for_view(self, user, coll_name):
         self.redir_host()
 

--- a/webrecorder/webrecorder/contentcontroller.py
+++ b/webrecorder/webrecorder/contentcontroller.py
@@ -301,6 +301,8 @@ class ContentController(BaseController, RewriterApp):
 
             return res
 
+        wr_api_spec.set_curr_tag('Add External Records')
+
         @self.app.route('/api/v1/remote/put-record', method='PUT')
         def do_put_record():
             return self.do_put_record()

--- a/webrecorder/webrecorder/downloadcontroller.py
+++ b/webrecorder/webrecorder/downloadcontroller.py
@@ -6,7 +6,7 @@ from pywb.utils.io import StreamIter, chunk_encode_iter
 
 from webrecorder.basecontroller import BaseController
 from webrecorder import __version__
-
+from webrecorder.apiutils import wr_api_spec
 from webrecorder.models.stats import Stats
 from webrecorder.utils import get_bool
 
@@ -34,6 +34,8 @@ class DownloadController(BaseController):
         self.download_chunk_encoded = config['download_chunk_encoded']
 
     def init_routes(self):
+        wr_api_spec.set_curr_tag('Downloads')
+
         @self.app.get('/<user>/<coll>/<rec>/$download')
         def logged_in_download_rec_warc(user, coll, rec):
             self.redir_host()
@@ -46,13 +48,25 @@ class DownloadController(BaseController):
 
             return self.handle_download(user, coll, '*')
 
+        wr_api_spec.set_curr_tag('WASAPI')
+
         @self.app.get('/api/v1/download/webdata')
+        @self.api(
+            query=['?user', '?collection', '?commit'],
+            resp='wasapi_list',
+            description='List all files available for download, their locations and checksums, per WASAPI spec'
+        )
         def wasapi_list_api():
             return self.wasapi_list()
 
         @self.app.get('/api/v1/download/<user>/<coll>/<filename>')
+        @self.api(
+            description='Download the specified WARC from a users collection, per WASAPI spec'
+        )
         def wasapi_download_api(user, coll, filename):
             return self.wasapi_download(user, coll, filename)
+
+        wr_api_spec.set_curr_tag(None)
 
     def create_warcinfo(self, creator, name, metadata, source, serialized, filename):
         for key, value in iteritems(serialized):
@@ -210,7 +224,7 @@ class DownloadController(BaseController):
         username = request.query.getunicode('user')
 
         # some clients use collection rather than coll_name so we must check for both
-        coll_name = request.query.getunicode('coll_name') or request.query.getunicode('collection')
+        coll_name = request.query.getunicode('collection')
         commit = get_bool(request.query.getunicode('commit'))
 
         user = self._get_wasapi_user()
@@ -283,7 +297,7 @@ class DownloadController(BaseController):
         if not collection:
             self._raise_error(404, 'no_such_collection')
 
-        #self.access.assert_is_curr_user(user)
+        # self.access.assert_is_curr_user(user)
         # only users with write access can use wasapi
         self.access.assert_can_write_coll(collection)
 

--- a/webrecorder/webrecorder/downloadcontroller.py
+++ b/webrecorder/webrecorder/downloadcontroller.py
@@ -48,8 +48,6 @@ class DownloadController(BaseController):
 
             return self.handle_download(user, coll, '*')
 
-        wr_api_spec.set_curr_tag('WASAPI')
-
         @self.app.get('/api/v1/download/webdata')
         @self.api(
             query=['?user', '?collection', '?commit'],
@@ -61,6 +59,7 @@ class DownloadController(BaseController):
 
         @self.app.get('/api/v1/download/<user>/<coll>/<filename>')
         @self.api(
+            resp='wasapi_download',
             description='Download the specified WARC from a users collection, per WASAPI spec'
         )
         def wasapi_download_api(user, coll, filename):

--- a/webrecorder/webrecorder/listscontroller.py
+++ b/webrecorder/webrecorder/listscontroller.py
@@ -203,6 +203,8 @@ class ListsController(BaseController):
             else:
                 self._raise_error(400, 'invalid_order')
 
+        wr_api_spec.set_curr_tag(None)
+
     def load_user_coll_list(self, list_id=None, user=None, coll_name=None):
         if not list_id:
             list_id = request.query.getunicode('list')

--- a/webrecorder/webrecorder/maincontroller.py
+++ b/webrecorder/webrecorder/maincontroller.py
@@ -393,10 +393,15 @@ class MainController(BaseController):
             self.flash_message(message, msg_type)
             return {}
 
-        @self.bottle_app.route('/api/v1')
-        def get_api_spec():
+        @self.bottle_app.route('/api/v1.yml')
+        def get_api_spec_yaml():
             response.content_type = 'text/yaml'
             return wr_api_spec.get_api_spec_yaml()
+
+        @self.bottle_app.route('/api/v1.json')
+        def get_api_spec_json():
+            response.content_type = 'application/json'
+            return json.dumps(wr_api_spec.get_api_spec_dict())
 
         @self.bottle_app.route('/<:re:.*>', method='ANY')
         def fallthrough():

--- a/webrecorder/webrecorder/models/usermanager.py
+++ b/webrecorder/webrecorder/models/usermanager.py
@@ -32,7 +32,7 @@ class UserManager(object):
 
     RESTRICTED_NAMES = ['login', 'logout', 'user', 'admin', 'manager', 'coll', 'collection',
                         'guest', 'settings', 'profile', 'api', 'anon', 'webrecorder',
-                        'anonymous', 'register', 'join', 'download', 'live', 'embed']
+                        'anonymous', 'register', 'join', 'download', 'live', 'embed', 'docs']
 
     PASS_RX = re.compile(r'^(?=.*[\d\W])(?=.*[a-z])(?=.*[A-Z]).{8,}$')
 

--- a/webrecorder/webrecorder/recscontroller.py
+++ b/webrecorder/webrecorder/recscontroller.py
@@ -162,6 +162,8 @@ class RecsController(BaseController):
 
             return recording.delete_page(url, ts)
 
+        wr_api_spec.set_curr_tag(None)
+
     def load_recording(self, rec, user=None, coll_name=None):
         user, collection = self.load_user_coll(user=user, coll_name=coll_name)
         if not user or not collection:

--- a/webrecorder/webrecorder/uploadcontroller.py
+++ b/webrecorder/webrecorder/uploadcontroller.py
@@ -1,3 +1,4 @@
+from webrecorder.apiutils import wr_api_spec
 from webrecorder.basecontroller import BaseController
 from webrecorder.models.importer import UploadImporter
 from webrecorder.models.stats import Stats
@@ -16,6 +17,8 @@ class UploadController(BaseController):
                                        wam_loader=content_app.wam_loader)
 
     def init_routes(self):
+        wr_api_spec.set_curr_tag('Uploads')
+
         @self.app.put(['/_upload', '/api/v1/upload'])
         def upload_file():
             user = self.access.session_user

--- a/webrecorder/webrecorder/usercontroller.py
+++ b/webrecorder/webrecorder/usercontroller.py
@@ -326,3 +326,4 @@ class UserController(BaseController):
 
             return result
 
+        wr_api_spec.set_curr_tag(None)


### PR DESCRIPTION
documented the wasapi api in WR's open api spec fixes #750 
- the /api/v1 endpoint is now two endpoints serving the spec as json or yaml
 - ensured that the tags set via wr_api_spec.set_curr_tag in the init_routes method of a controller are isolated to that part of the api
 - added open api tags for WASAPI, Automation, and Behaviors and ensured that those routes are tagged appropriately
 - added test for the /api/via/download/webdata endpoint
 - added ability to mark query params as optional when defining the spec for a route