### PR TITLE
WASAPI Include 'open' WARCs

### DIFF
--- a/webrecorder/test/test_api_user_login.py
+++ b/webrecorder/test/test_api_user_login.py
@@ -493,7 +493,7 @@ class TestApiUserLogin(FullStackTests):
 
         get = web_data.get('get')
         assert get is not None
-        assert len(get.get('parameters')) == 3
+        assert len(get.get('parameters')) == 2
         assert len(get.get('tags')) == 1
         assert 'WASAPI' in get.get('responses').get('200').get('description')
         assert get.get('tags')[0] == 'WASAPI (Downloads)'

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -304,9 +304,14 @@ class TestRegisterMigrate(FullStackTests):
 
     def test_wasapi_list(self):
         res = self.testapp.get('/api/v1/download/webdata')
-        assert len(res.json['files']) == 1
+        assert len(res.json['files']) == 2
         assert res.json['files'][0]['checksums']
         assert res.json['files'][0]['locations']
+
+        assert res.json['files'][1]['checksums']
+        assert res.json['files'][1]['locations']
+
+        assert sum((1 if val['is_open'] else 0 for val in res.json['files']), 0) == 1
 
         wasapi_filename = res.json['files'][0]['locations'][0]
         res = self.testapp.head(urlsplit(wasapi_filename).path)
@@ -463,9 +468,11 @@ class TestRegisterMigrate(FullStackTests):
         res = self.testapp.get('/api/v1/download/webdata')
         self.testapp.authorization = None
 
-        assert len(res.json['files']) == 1
+        assert len(res.json['files']) == 3
         assert res.json['files'][0]['checksums']
         assert res.json['files'][0]['locations']
+
+        assert sum((1 if val['is_open'] else 0 for val in res.json['files']), 0) == 2
 
         wasapi_filename = res.json['files'][0]['locations'][0]
 

--- a/webrecorder/test/test_register_migrate.py
+++ b/webrecorder/test/test_register_migrate.py
@@ -311,7 +311,7 @@ class TestRegisterMigrate(FullStackTests):
         assert res.json['files'][1]['checksums']
         assert res.json['files'][1]['locations']
 
-        assert sum((1 if val['is_open'] else 0 for val in res.json['files']), 0) == 1
+        assert sum((1 if val['is_active'] else 0 for val in res.json['files']), 0) == 1
 
         wasapi_filename = res.json['files'][0]['locations'][0]
         res = self.testapp.head(urlsplit(wasapi_filename).path)
@@ -472,7 +472,7 @@ class TestRegisterMigrate(FullStackTests):
         assert res.json['files'][0]['checksums']
         assert res.json['files'][0]['locations']
 
-        assert sum((1 if val['is_open'] else 0 for val in res.json['files']), 0) == 2
+        assert sum((1 if val['is_active'] else 0 for val in res.json['files']), 0) == 2
 
         wasapi_filename = res.json['files'][0]['locations'][0]
 

--- a/webrecorder/test/test_storage_commit.py
+++ b/webrecorder/test/test_storage_commit.py
@@ -305,7 +305,8 @@ class TestS3Storage(BaseStorageCommit):
 
     def assert_wasapi_locations(self, file_entry, verify_only=True):
         locations = file_entry.get('locations', [])
-        assert list(file_entry.get('checksums').keys())[0] == 's3etag'
+        hash_type = list(file_entry.get('checksums').keys())[0]
+        assert hash_type == 's3etag' or hash_type == 'md5'
         assert len(locations) == 2
         if verify_only:
             return

--- a/webrecorder/webrecorder/apiutils.py
+++ b/webrecorder/webrecorder/apiutils.py
@@ -96,7 +96,6 @@ class WRAPISpec(object):
     }
 
     opt_bool_params = {
-        'commit': 'Force all non-committed recording to become committed',
         'public': 'Publicly Accessible',
         'include_recordings': 'Include Recording Sessions in response',
         'include_lists': 'Include all lists in response',
@@ -139,6 +138,7 @@ class WRAPISpec(object):
                                         'collection': {'type': 'string'},
                                         'checksums': {'type': 'object'},
                                         'locations': {'type': 'array', 'items': {'type': 'string'}},
+                                        'is_open': {'type': 'boolean'},
                                     }
                                 }
                             },

--- a/webrecorder/webrecorder/apiutils.py
+++ b/webrecorder/webrecorder/apiutils.py
@@ -138,7 +138,7 @@ class WRAPISpec(object):
                                         'collection': {'type': 'string'},
                                         'checksums': {'type': 'object'},
                                         'locations': {'type': 'array', 'items': {'type': 'string'}},
-                                        'is_open': {'type': 'boolean'},
+                                        'is_active': {'type': 'boolean'},
                                     }
                                 }
                             },

--- a/webrecorder/webrecorder/downloadcontroller.py
+++ b/webrecorder/webrecorder/downloadcontroller.py
@@ -9,6 +9,7 @@ from webrecorder import __version__
 from webrecorder.apiutils import wr_api_spec
 from webrecorder.models.stats import Stats
 from webrecorder.utils import get_bool
+from webrecorder.rec.storage import LocalFileStorage
 
 from bottle import response, request
 from six.moves.urllib.parse import quote
@@ -50,7 +51,7 @@ class DownloadController(BaseController):
 
         @self.app.get('/api/v1/download/webdata')
         @self.api(
-            query=['?user', '?collection', '?commit'],
+            query=['?user', '?collection'],
             resp='wasapi_list',
             description='List all files available for download, their locations and checksums, per WASAPI spec'
         )
@@ -224,7 +225,6 @@ class DownloadController(BaseController):
 
         # some clients use collection rather than coll_name so we must check for both
         coll_name = request.query.getunicode('collection')
-        commit = get_bool(request.query.getunicode('commit'))
 
         user = self._get_wasapi_user()
 
@@ -246,16 +246,13 @@ class DownloadController(BaseController):
         download_path = self.get_origin() + '/api/v1/download/{user}/{coll}/{filename}'
 
         for collection in colls:
-            if commit:
-                commit_id = collection.commit_all()
-                while commit_id:
-                    gevent.sleep(10)
-                    commit_id = collection.commit_all(commit_id)
+            commit_storage = collection.get_storage()
+            local_storage = LocalFileStorage(self.redis)
 
-            storage = collection.get_storage()
             for recording in collection.get_recordings():
-                if not recording.is_fully_committed():
-                    continue
+                is_open = not recording.is_fully_committed()
+                print('IS OPEN', is_open)
+                storage = commit_storage if not is_open else local_storage
 
                 for name, path in recording.iter_all_files(include_index=False):
                     full_warc_path = collection.get_warc_path(name)
@@ -265,7 +262,7 @@ class DownloadController(BaseController):
 
                     # if remote download url exists (eg. for s3), include that first
                     # always include local download url as well
-                    if remote_download_url:
+                    if remote_download_url and not is_open:
                         locations = [remote_download_url, local_download]
                     else:
                         locations = [local_download]
@@ -281,9 +278,10 @@ class DownloadController(BaseController):
                         'collection': collection.name,
                         'checksums': {kind: check_sum},
                         'locations': locations,
+                        'is_open': is_open,
                     })
 
-        return {'files': files, 'include-extra': True}
+        return {'files': files, 'include-extra': len(files) > 0}
 
     def wasapi_download(self, username, coll_name, filename):
         user = self._get_wasapi_user(username)

--- a/webrecorder/webrecorder/downloadcontroller.py
+++ b/webrecorder/webrecorder/downloadcontroller.py
@@ -244,10 +244,10 @@ class DownloadController(BaseController):
 
         files = []
         download_path = self.get_origin() + '/api/v1/download/{user}/{coll}/{filename}'
+        local_storage = LocalFileStorage(self.redis)
 
         for collection in colls:
             commit_storage = collection.get_storage()
-            local_storage = LocalFileStorage(self.redis)
 
             for recording in collection.get_recordings():
                 is_committed = recording.is_fully_committed()

--- a/webrecorder/webrecorder/rec/storage/s3.py
+++ b/webrecorder/webrecorder/rec/storage/s3.py
@@ -158,6 +158,8 @@ class S3Storage(BaseStorage):
             res = self.s3.head_object(Bucket=self.bucket_name,
                                       Key=path)
             # strip off quotes and return md5
-            return 's3etag', res['ETag'][1:-1], res['ContentLength']
+            etag = res['ETag'][1:-1]
+            kind = 's3etag' if '-' in etag else 'md5'
+            return kind, etag, res['ContentLength']
         except Exception:
             return None, None, None

--- a/webrecorder/webrecorder/rec/storage/s3.py
+++ b/webrecorder/webrecorder/rec/storage/s3.py
@@ -158,6 +158,6 @@ class S3Storage(BaseStorage):
             res = self.s3.head_object(Bucket=self.bucket_name,
                                       Key=path)
             # strip off quotes and return md5
-            return 'etag', res['ETag'][1:-1], res['ContentLength']
+            return 's3etag', res['ETag'][1:-1], res['ContentLength']
         except Exception:
             return None, None, None


### PR DESCRIPTION
To avoid confusion about active WARCs not being included, include them as well
- If recording is active, set `is_active` to true.. This means a WARC *may* change in the future.
- If recording is active and there is pending traffic, eg. video being downloaded, change WARC extension to `.warc.gz.open` to indicate the WARC *will* change once the pending request lands.
Checksums for open WARCs will likely change as well, so they shouldn't yet be used, but indicate the latest content available.
Also, for S3, use `s3etag` if custom S3 etag, and plain `md5` if etag is really just an md5