### PR TITLE
Shepherd 1.2 Update

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -115,12 +115,17 @@ services:
             - 8092:81
 
     behaviors:
-      container_name: behaviors
-      image: "webrecorder/behaviors:latest"
+        container_name: behaviors
+        image: "webrecorder/behaviors:latest"
+
+    coturn:
+        image: oldwebtoday/coturn:1.0
+        ports:
+            - 33478:33478
 
     shepherd:
         container_name: shepherd
-        image: oldwebtoday/shepherd:1.1.0
+        image: oldwebtoday/shepherd:1.2.0
 
         env_file:
             - ./wr.env

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,9 +119,17 @@ services:
         image: "webrecorder/behaviors:latest"
 
     coturn:
+        container_name: coturn
         image: oldwebtoday/coturn:1.0
         ports:
-            - 33478:33478
+            - "33478:33478/tcp"
+            - "33478:33478/udp"
+
+        networks:
+            - browsers
+
+        env_file:
+            - ./wr.env
 
     shepherd:
         container_name: shepherd
@@ -139,7 +147,7 @@ services:
             - PROXY_GET_CA=http://wsgiprox/download/pem
 
             - CONTAINER_EXPIRE_SECS=3600
-            - IDLE_TIMEOUT=120
+            - IDLE_TIMEOUT=5
 
             - BROWSER_NET=webrecorder_browsers
             - MAIN_NET=webrecorder_default

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -98,7 +98,7 @@
     "resolve-url-loader": "^2.3.0",
     "sass-loader": "^7.1.0",
     "serialize-javascript": "^1.5.0",
-    "shepherd-client": "github:oldweb-today/shepherd-client#master",
+    "shepherd-client": "github:oldweb-today/shepherd-client#1.2.0",
     "strip-loader": "^0.1.2",
     "style-loader": "0.23.1",
     "superagent": "^4.0.0",

--- a/frontend/src/components/controls/RemoteBrowserUI/index.js
+++ b/frontend/src/components/controls/RemoteBrowserUI/index.js
@@ -74,6 +74,7 @@ class RemoteBrowserUI extends Component {
       on_event: this.onEvent,
       headers: { 'x-requested-with': 'XMLHttpRequest' },
       webrtc: true,
+      webrtc_video: false,
       webrtcHostIP: publicIP,
     };
   }

--- a/install-browsers.sh
+++ b/install-browsers.sh
@@ -7,7 +7,7 @@
 # By default, only latest versions of browsers are pulled. Uncomment other versions to include them as well.
 
 # Remote Desktop System and Base Browser (Required for all browsers)
-docker pull oldwebtoday/vnc-webrtc-audio
+docker pull oldwebtoday/remote-desktop-server
 docker pull oldwebtoday/base-displayaudio
 docker pull oldwebtoday/base-browser
 


### PR DESCRIPTION
Update to latest shepherd system, including support for turn server for WebRTC to ensure audio works on restricted networks. (Full WebRTC available but not enabled)