### PR TITLE
Create Allow to access to third party cloud services

### DIFF
--- a/webrecorder/Allow to access to third party cloud services
+++ b/webrecorder/Allow to access to third party cloud services
@@ -1,0 +1,1 @@
+allow to access to ,OneDrive,Google Drive,and Dropbox.


### PR DESCRIPTION
Allow conifer to accept warcs from third party cloud services like for in this case Google drive or Microsoft OneDrive or Dropbox services.