### PR TITLE
Allow access from third party cloud services

### DIFF
--- a/Allow access from third party cloud services.
+++ b/Allow access from third party cloud services.
@@ -1,0 +1,7 @@
+allow conifer to access warcs from third party cloud services like.
+dropbox,
+google drive,
+microsoft onedrive,
+icloud,
+onebox,
+


### PR DESCRIPTION
This new feature will or would be helpful to allow conifer to accept and handle warcs from third party cloud services which will be added to the new improvements list for conifer Deploy and interface.